### PR TITLE
Environment variables management update

### DIFF
--- a/src/Cli/InstallCommand.php
+++ b/src/Cli/InstallCommand.php
@@ -30,5 +30,7 @@ class InstallCommand extends Command
 
         $installer = new DockerInstaller();
         $installer->install($userInteraction);
+
+        pcntl_exec(getenv('SHELL'));
     }
 }

--- a/src/Installer/Docker/Dinghy.php
+++ b/src/Installer/Docker/Dinghy.php
@@ -61,40 +61,11 @@ class Dinghy extends InstallerTask implements DependentChainProcessInterface
         } else {
             $this->userInteraction->writeTitle('Dinghy already started');
         }
-
-        if (!$this->haveDinghyEnvironmentVariables()) {
-            $this->userInteraction->writeTitle('Setting up dinghy environment variables');
-            $this->setupDinghyEnvironmentVariables();
-        }
     }
 
     private function installDinghy()
     {
         $this->processRunner->run(new Process('brew install https://github.com/codekitchen/dinghy/raw/latest/dinghy.rb'));
-    }
-
-    private function haveDinghyEnvironmentVariables()
-    {
-        return getenv('DOCKER_HOST') !== false;
-    }
-
-    private function setupDinghyEnvironmentVariables()
-    {
-        $userHome = getenv('HOME');
-        $environmentVariables = [
-            new EnvironmentVariable('DOCKER_HOST', 'tcp://127.0.0.1:2376'),
-            new EnvironmentVariable('DOCKER_CERT_PATH', $userHome.'/.dinghy/certs'),
-            new EnvironmentVariable('DOCKER_TLS_VERIFY', '1'),
-        ];
-
-        $environManipulatorFactory = new EnvironManipulatorFactory();
-        $environManipulator = $environManipulatorFactory->getSystemManipulator($this->processRunner);
-
-        foreach ($environmentVariables as $environmentVariable) {
-            if (!$environManipulator->has($environmentVariable)) {
-                $environManipulator->save($environmentVariable);
-            }
-        }
     }
 
     private function changeDinghyDnsResolverNamespace()

--- a/src/Installer/Docker/EnvironmentVariables.php
+++ b/src/Installer/Docker/EnvironmentVariables.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Dock\Installer\Docker;
+
+use Dock\Installer\InstallContext;
+use Dock\Installer\InstallerTask;
+use Dock\System\Environ\EnvironManipulatorFactory;
+use Dock\System\Environ\EnvironmentVariable;
+use SRIO\ChainOfResponsibility\DependentChainProcessInterface;
+
+class EnvironmentVariables extends InstallerTask implements DependentChainProcessInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function run(InstallContext $context)
+    {
+        $userInteraction = $context->getUserInteraction();
+        if ($this->isEnvironmentConfigured()) {
+            $userInteraction->write('Environment variables are already configured');
+
+            return;
+        }
+
+        $userInteraction->writeTitle('Setting up dinghy environment variables');
+        $processRunner = $context->getProcessRunner();
+
+        $userHome = getenv('HOME');
+        $environmentVariables = [
+            new EnvironmentVariable('DOCKER_HOST', 'tcp://127.0.0.1:2376'),
+            new EnvironmentVariable('DOCKER_CERT_PATH', $userHome.'/.dinghy/certs'),
+            new EnvironmentVariable('DOCKER_TLS_VERIFY', '1'),
+        ];
+
+        $environManipulatorFactory = new EnvironManipulatorFactory();
+        $environManipulator = $environManipulatorFactory->getSystemManipulator($processRunner);
+
+        foreach ($environmentVariables as $environmentVariable) {
+            if (!$environManipulator->has($environmentVariable)) {
+                $environManipulator->save($environmentVariable);
+            }
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function isEnvironmentConfigured()
+    {
+        return getenv('DOCKER_HOST') == 'tcp://127.0.0.1:2376';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dependsOn()
+    {
+        return ['dinghy'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'shell-env';
+    }
+}

--- a/src/Installer/DockerInstaller.php
+++ b/src/Installer/DockerInstaller.php
@@ -5,6 +5,7 @@ namespace Dock\Installer;
 use Dock\Installer\DNS\DnsDock;
 use Dock\Installer\DNS\DockerRouting;
 use Dock\Installer\Docker\Dinghy;
+use Dock\Installer\Docker\EnvironmentVariables;
 use Dock\Installer\System\BrewCask;
 use Dock\Installer\System\DockerCompose;
 use Dock\Installer\System\Homebrew;
@@ -44,6 +45,7 @@ class DockerInstaller
             new Vagrant(),
             new VirtualBox(),
             new DockerCompose(),
+            new EnvironmentVariables(),
         ];
     }
 }

--- a/src/System/Environ/BashEnvironManipulator.php
+++ b/src/System/Environ/BashEnvironManipulator.php
@@ -30,11 +30,14 @@ class BashEnvironManipulator implements EnvironManipulator
      */
     public function save(EnvironmentVariable $environmentVariable)
     {
-        $command = 'echo "' . $environmentVariable->getName() . '=' . $environmentVariable->getValue(
-            ) . '" >> ' . $this->file;
-        $process = new Process($command);
+        $command = sprintf(
+            'echo "export %s=%s" >> %s',
+            $environmentVariable->getName(),
+            $environmentVariable->getValue(),
+            $this->file
+        );
 
-        $this->processRunner->run($process);
+        $this->processRunner->run(new Process($command));
     }
 
     /**


### PR DESCRIPTION
- Move the environment variable setup process in its own class
- Reload shell after installation command (which fixes #9)

For free, restart Dinghy only if required.
