### PR TITLE
Introduce a new `ps` command that displays containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following commands are available:
 ### Project commands
 
 - [`up` command](docs/cmd-up.md) starts the Docker environment for the project.
+- [`ps` command](docs/cmd-ps.md) list all the project containers if any.
 
 ## Update
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "app.php"
   ],
   "require-dev": {
-    "kherge/box": "~2.5"
+    "kherge/box": "~2.5",
+    "fabpot/php-cs-fixer": "~1.9"
   }
 }

--- a/docs/cmd-ps.md
+++ b/docs/cmd-ps.md
@@ -1,0 +1,10 @@
+# `ps` command
+
+List all running or exited application containers. This will also display the DNS addresses of the
+given containers and their exposed port.
+
+## Usage
+
+```
+dock-cli ps
+```

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -24,6 +24,7 @@ class Application extends ConsoleApplication
 
             // Project commands
             new UpCommand(),
+            new PsCommand(),
         ];
     }
 }

--- a/src/Cli/Helper/ContainerList.php
+++ b/src/Cli/Helper/ContainerList.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Dock\Cli\Helper;
+
+use Dock\Compose\Container;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ContainerList
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * @param Container[] $containers
+     */
+    public function render(array $containers)
+    {
+        $table = new Table($this->output);
+        $table->setHeaders(['Name', 'DNS addresses', 'Port(s)', 'Status']);
+
+        foreach ($containers as $index => $container) {
+            if ($index > 0) {
+                $table->addRow(new TableSeparator());
+            }
+
+            $table->addRow([
+                $container->getName(),
+                implode("\n", $container->getHosts()),
+                implode("\n", $container->getPorts()),
+                $this->getDecoratedState($container)
+            ]);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * @param Container $container
+     * @return string
+     */
+    private function getDecoratedState(Container $container)
+    {
+        if ($container->getState() === Container::STATE_EXITED) {
+            return '<error>'.$container->getState().'</error>';
+        }
+
+        return $container->getState();
+    }
+}

--- a/src/Cli/Helper/ContainerList.php
+++ b/src/Cli/Helper/ContainerList.php
@@ -39,7 +39,7 @@ class ContainerList
                 $container->getName(),
                 implode("\n", $container->getHosts()),
                 implode("\n", $container->getPorts()),
-                $this->getDecoratedState($container)
+                $this->getDecoratedState($container),
             ]);
         }
 
@@ -48,6 +48,7 @@ class ContainerList
 
     /**
      * @param Container $container
+     *
      * @return string
      */
     private function getDecoratedState(Container $container)

--- a/src/Cli/PsCommand.php
+++ b/src/Cli/PsCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Dock\Cli;
+
+use Dock\Cli\IO\ConsoleUserInteraction;
+use Dock\Compose\Container;
+use Dock\Compose\Inspector;
+use Dock\Installer\InteractiveProcessRunner;
+use Dock\IO\ProcessRunner;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class PsCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ps')
+            ->setDescription('List running containers')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $userInteraction = new ConsoleUserInteraction($input, $output);
+        $processRunner = new InteractiveProcessRunner($userInteraction);
+
+        $inspector = new Inspector($processRunner);
+        $containers = $inspector->getRunningContainers();
+
+        $table = new Table($output);
+        $table->setHeaders(['Name', 'DNS addresses', 'Port(s)', 'Status']);
+
+        foreach ($containers as $index => $container) {
+            if ($index > 0) {
+                $table->addRow(new TableSeparator());
+            }
+
+            $table->addRow([
+                $container->getName(),
+                implode("\n", $container->getHosts()),
+                implode("\n", $container->getPorts()),
+                $this->getDecoratedState($container)
+            ]);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * @param Container $container
+     * @return string
+     */
+    private function getDecoratedState(Container $container)
+    {
+        if ($container->getState() === Container::STATE_EXITED) {
+            return '<error>'.$container->getState().'</error>';
+        }
+
+        return $container->getState();
+    }
+}

--- a/src/Cli/PsCommand.php
+++ b/src/Cli/PsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Dock\Cli;
 
+use Dock\Cli\Helper\ContainerList;
 use Dock\Cli\IO\ConsoleUserInteraction;
 use Dock\Compose\Container;
 use Dock\Compose\Inspector;
@@ -40,35 +41,7 @@ class PsCommand extends Command
         $inspector = new Inspector($processRunner);
         $containers = $inspector->getRunningContainers();
 
-        $table = new Table($output);
-        $table->setHeaders(['Name', 'DNS addresses', 'Port(s)', 'Status']);
-
-        foreach ($containers as $index => $container) {
-            if ($index > 0) {
-                $table->addRow(new TableSeparator());
-            }
-
-            $table->addRow([
-                $container->getName(),
-                implode("\n", $container->getHosts()),
-                implode("\n", $container->getPorts()),
-                $this->getDecoratedState($container)
-            ]);
-        }
-
-        $table->render();
-    }
-
-    /**
-     * @param Container $container
-     * @return string
-     */
-    private function getDecoratedState(Container $container)
-    {
-        if ($container->getState() === Container::STATE_EXITED) {
-            return '<error>'.$container->getState().'</error>';
-        }
-
-        return $container->getState();
+        $list = new ContainerList($output);
+        $list->render($containers);
     }
 }

--- a/src/Cli/PsCommand.php
+++ b/src/Cli/PsCommand.php
@@ -7,6 +7,7 @@ use Dock\Compose\Container;
 use Dock\Compose\Inspector;
 use Dock\Installer\InteractiveProcessRunner;
 use Dock\IO\ProcessRunner;
+use Dock\IO\SilentProcessRunner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
@@ -34,7 +35,7 @@ class PsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $userInteraction = new ConsoleUserInteraction($input, $output);
-        $processRunner = new InteractiveProcessRunner($userInteraction);
+        $processRunner = new SilentProcessRunner($userInteraction);
 
         $inspector = new Inspector($processRunner);
         $containers = $inspector->getRunningContainers();

--- a/src/Cli/PsCommand.php
+++ b/src/Cli/PsCommand.php
@@ -4,18 +4,11 @@ namespace Dock\Cli;
 
 use Dock\Cli\Helper\ContainerList;
 use Dock\Cli\IO\ConsoleUserInteraction;
-use Dock\Compose\Container;
 use Dock\Compose\Inspector;
-use Dock\Installer\InteractiveProcessRunner;
-use Dock\IO\ProcessRunner;
 use Dock\IO\SilentProcessRunner;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class PsCommand extends Command
 {

--- a/src/Compose/Container.php
+++ b/src/Compose/Container.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Dock\Compose;
+
+class Container
+{
+    const STATE_UNKNOWN = 'unknown';
+    const STATE_RUNNING = 'running';
+    const STATE_EXITED = 'exited';
+
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var string
+     */
+    private $image;
+    /**
+     * @var array
+     */
+    private $hosts;
+    /**
+     * @var string
+     */
+    private $state;
+    /**
+     * @var array
+     */
+    private $ports;
+
+    /**
+     * @param string $name
+     * @param string $image
+     * @param string $state
+     * @param array $hosts
+     * @param array $ports
+     */
+    public function __construct($name, $image, $state = self::STATE_UNKNOWN, array $hosts = [], array $ports = [])
+    {
+        $this->name = $name;
+        $this->image = $image;
+        $this->hosts = $hosts;
+        $this->state = $state;
+        $this->ports = $ports;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHosts()
+    {
+        return $this->hosts;
+    }
+
+    /**
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPorts()
+    {
+        return $this->ports;
+    }
+}

--- a/src/Compose/Container.php
+++ b/src/Compose/Container.php
@@ -33,8 +33,8 @@ class Container
      * @param string $name
      * @param string $image
      * @param string $state
-     * @param array $hosts
-     * @param array $ports
+     * @param array  $hosts
+     * @param array  $ports
      */
     public function __construct($name, $image, $state = self::STATE_UNKNOWN, array $hosts = [], array $ports = [])
     {

--- a/src/Compose/Inspector.php
+++ b/src/Compose/Inspector.php
@@ -49,13 +49,14 @@ class Inspector
     /**
      * @param string $containerName
      * @param string $containerImage
+     *
      * @return array
      */
     private function getDnsByContainerNameAndImage($containerName, $containerImage)
     {
         return [
             $containerImage.'.docker',
-            $containerName.'.'.$containerImage.'.docker'
+            $containerName.'.'.$containerImage.'.docker',
         ];
     }
 

--- a/src/Compose/Inspector.php
+++ b/src/Compose/Inspector.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Dock\Compose;
+
+use Dock\IO\ProcessRunner;
+use Symfony\Component\Process\Process;
+
+class Inspector
+{
+    /**
+     * @var ProcessRunner
+     */
+    private $processRunner;
+
+    /**
+     * @param ProcessRunner $processRunner
+     */
+    public function __construct(ProcessRunner $processRunner)
+    {
+        $this->processRunner = $processRunner;
+    }
+
+    /**
+     * @return Container[]
+     */
+    public function getRunningContainers()
+    {
+        $containerIds = $this->getRunningContainerIds();
+        $containers = [];
+
+        foreach ($containerIds as $containerId) {
+            $inspection = $this->inspectContainer($containerId);
+            $containerName = substr($inspection['Name'], 1);
+            $imageName = $inspection['Config']['Image'];
+            $exposedPorts = isset($inspection['Config']['ExposedPorts']) ? array_keys($inspection['Config']['ExposedPorts']) : [];
+
+            $containers[] = new Container(
+                $containerName,
+                $imageName,
+                $inspection['State']['Running'] ? Container::STATE_RUNNING : Container::STATE_EXITED,
+                $this->getDnsByContainerNameAndImage($containerName, $imageName),
+                $exposedPorts
+            );
+        }
+
+        return $containers;
+    }
+
+    /**
+     * @param string $containerName
+     * @param string $containerImage
+     * @return array
+     */
+    private function getDnsByContainerNameAndImage($containerName, $containerImage)
+    {
+        return [
+            $containerImage.'.docker',
+            $containerName.'.'.$containerImage.'.docker'
+        ];
+    }
+
+    /**
+     * @param string $containerId
+     *
+     * @return array
+     */
+    private function inspectContainer($containerId)
+    {
+        $command = sprintf('docker inspect %s', $containerId);
+        $rawOutput = $this->processRunner->run(new Process($command))->getOutput();
+        $rawOutput = trim($rawOutput);
+
+        if (null === ($inspection = json_decode($rawOutput, true))) {
+            throw new \RuntimeException('Unable to inspect container');
+        }
+
+        return $inspection[0];
+    }
+
+    /**
+     * @return array
+     */
+    private function getRunningContainerIds()
+    {
+        $rawOutput = $this->processRunner->run(new Process('docker-compose ps -q'))->getOutput();
+        $lines = explode("\n", $rawOutput);
+        $containerIds = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if (!empty($line)) {
+                $containerIds[] = $line;
+            }
+        }
+
+        return $containerIds;
+    }
+}

--- a/src/IO/SilentProcessRunner.php
+++ b/src/IO/SilentProcessRunner.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dock\IO;
+
+use Symfony\Component\Process\Process;
+
+class SilentProcessRunner implements ProcessRunner
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function run(Process $process, $mustSucceed = true)
+    {
+        if ($mustSucceed) {
+            $process->setTimeout(null);
+
+            return $process->mustRun();
+        }
+
+        $process->run();
+
+        return $process;
+    }
+}

--- a/src/Installer/Docker/Dinghy.php
+++ b/src/Installer/Docker/Dinghy.php
@@ -8,8 +8,6 @@ use Dock\Installer\InstallContext;
 use Dock\Installer\InstallerTask;
 use Dock\IO\ProcessRunner;
 use Dock\IO\UserInteraction;
-use Dock\System\Environ\EnvironManipulatorFactory;
-use Dock\System\Environ\EnvironmentVariable;
 use SRIO\ChainOfResponsibility\DependentChainProcessInterface;
 use Symfony\Component\Process\Process;
 


### PR DESCRIPTION
This PR, needed by #8, introduce a new `ps` command that list all the running or exited containers of the application. The main thing is that it also display the containers' DNS.

Here's a screenshot of the current output:
<img width="460" alt="screen shot 2015-07-06 at 23 20 45" src="https://cloud.githubusercontent.com/assets/804625/8534648/2a5da3ca-2436-11e5-975a-e8b123290751.png">
