### PR TITLE
Display containers after `up` and introduce a `logs` command

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -25,6 +25,7 @@ class Application extends ConsoleApplication
             // Project commands
             new UpCommand(),
             new PsCommand(),
+            new LogsCommand(),
         ];
     }
 }

--- a/src/Cli/Helper/ContainerList.php
+++ b/src/Cli/Helper/ContainerList.php
@@ -28,7 +28,7 @@ class ContainerList
     public function render(array $containers)
     {
         $table = new Table($this->output);
-        $table->setHeaders(['Name', 'DNS addresses', 'Port(s)', 'Status']);
+        $table->setHeaders(['Component', 'Container', 'DNS addresses', 'Port(s)', 'Status']);
 
         foreach ($containers as $index => $container) {
             if ($index > 0) {
@@ -36,6 +36,7 @@ class ContainerList
             }
 
             $table->addRow([
+                $container->getComponentName(),
                 $container->getName(),
                 implode("\n", $container->getHosts()),
                 implode("\n", $container->getPorts()),

--- a/src/Cli/LogsCommand.php
+++ b/src/Cli/LogsCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Dock\Cli;
+
+use Dock\Cli\IO\ConsoleUserInteraction;
+use Dock\IO\ProcessRunner;
+use Dock\IO\SilentProcessRunner;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class LogsCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('logs')
+            ->setDescription('Follow logs of application containers')
+            ->addArgument('component', InputArgument::OPTIONAL, 'Name of component to follow')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $userInteraction = new ConsoleUserInteraction($input, $output);
+        $processRunner = new SilentProcessRunner($userInteraction);
+
+        $composeLogsArguments = ['logs'];
+        if (null !== ($component = $input->getArgument('component'))) {
+            $composeLogsArguments[] = $component;
+        }
+
+        pcntl_exec($this->getDockerComposePath($processRunner), $composeLogsArguments);
+    }
+
+    /**
+     * @param ProcessRunner $processRunner
+     *
+     * @return string
+     */
+    private function getDockerComposePath(ProcessRunner $processRunner)
+    {
+        $output = $processRunner->run(new Process('which docker-compose'))->getOutput();
+
+        return trim($output);
+    }
+}

--- a/src/Cli/UpCommand.php
+++ b/src/Cli/UpCommand.php
@@ -2,11 +2,10 @@
 
 namespace Dock\Cli;
 
-use Dock\Cli\Helper\ContainerList;
 use Dock\Cli\IO\ConsoleUserInteraction;
-use Dock\Compose\Inspector;
 use Dock\IO\SilentProcessRunner;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -52,14 +51,10 @@ class UpCommand extends Command
             return 1;
         }
 
-        // Display running containers
-        $inspector = new Inspector($processRunner);
-        $containers = $inspector->getRunningContainers();
-
-        $list = new ContainerList($output);
-        $list->render($containers);
-
-        return 0;
+        return $this->getApplication()->run(
+            new ArrayInput(['command' => 'ps']),
+            $output
+        );
     }
 
     /**

--- a/src/Cli/UpCommand.php
+++ b/src/Cli/UpCommand.php
@@ -2,9 +2,10 @@
 
 namespace Dock\Cli;
 
+use Dock\Cli\Helper\ContainerList;
 use Dock\Cli\IO\ConsoleUserInteraction;
-use Dock\Installer\InteractiveProcessRunner;
-use Dock\IO\ProcessRunner;
+use Dock\Compose\Inspector;
+use Dock\IO\SilentProcessRunner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -30,7 +31,7 @@ class UpCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $userInteraction = new ConsoleUserInteraction($input, $output);
-        $processRunner = new InteractiveProcessRunner($userInteraction);
+        $processRunner = new SilentProcessRunner($userInteraction);
 
         if (!$this->inHomeDirectory()) {
             $output->writeln(
@@ -39,28 +40,36 @@ class UpCommand extends Command
 
             return 1;
         }
-        try {
-            $dockerComposePath = $this->getDockerComposePath($processRunner);
-            pcntl_exec($dockerComposePath, ['up']);
 
-            return 0;
+        $userInteraction->writeTitle('Starting application containers');
+
+        try {
+            $processRunner->run(new Process('docker-compose up -d'));
+            $userInteraction->writeTitle('Application containers successfully started');
         } catch (ProcessFailedException $e) {
+            echo $e->getProcess()->getOutput();
+
             return 1;
         }
+
+        // Display running containers
+        $inspector = new Inspector($processRunner);
+        $containers = $inspector->getRunningContainers();
+
+        $list = new ContainerList($output);
+        $list->render($containers);
+
+        return 0;
     }
 
+    /**
+     * @return bool
+     */
     private function inHomeDirectory()
     {
         $home = getenv('HOME');
         $pwd = getcwd();
 
         return substr($pwd, 0, strlen($home)) === $home;
-    }
-
-    private function getDockerComposePath(ProcessRunner $processRunner)
-    {
-        $output = $processRunner->run(new Process('which docker-compose'))->getOutput();
-
-        return trim($output);
     }
 }

--- a/src/Compose/Container.php
+++ b/src/Compose/Container.php
@@ -28,6 +28,10 @@ class Container
      * @var array
      */
     private $ports;
+    /**
+     * @var string
+     */
+    private $componentName;
 
     /**
      * @param string $name
@@ -35,14 +39,16 @@ class Container
      * @param string $state
      * @param array  $hosts
      * @param array  $ports
+     * @param string $componentName
      */
-    public function __construct($name, $image, $state = self::STATE_UNKNOWN, array $hosts = [], array $ports = [])
+    public function __construct($name, $image, $state = self::STATE_UNKNOWN, array $hosts = [], array $ports = [], $componentName = null)
     {
         $this->name = $name;
         $this->image = $image;
         $this->hosts = $hosts;
         $this->state = $state;
         $this->ports = $ports;
+        $this->componentName = $componentName;
     }
 
     /**
@@ -83,5 +89,13 @@ class Container
     public function getPorts()
     {
         return $this->ports;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComponentName()
+    {
+        return $this->componentName;
     }
 }


### PR DESCRIPTION
This PR introduces a `logs` command that follows application containers' logs, or a given container if its name is the second argument.

Moreover, to improve visibility of container list, it now displays the name of the component as defined in the `docker-compose.yml` file, not just the container name.

This fixes #8.
