### PR TITLE
Move instantiating a Process inside the process manager

### DIFF
--- a/src/Cli/IO/InteractiveProcessRunner.php
+++ b/src/Cli/IO/InteractiveProcessRunner.php
@@ -24,9 +24,11 @@ class InteractiveProcessRunner implements ProcessRunner
     /**
      * {@inheritdoc}
      */
-    public function run(Process $process, $mustSucceed = true)
+    public function run($command, $mustSucceed = true)
     {
-        $this->userInteraction->write('<info>RUN</info> '.$process->getCommandLine());
+        $process = new Process($command);
+
+        $this->userInteraction->write('<info>RUN</info> ' . $process->getCommandLine());
 
         if ($mustSucceed) {
             $process->setTimeout(null);
@@ -55,7 +57,7 @@ class InteractiveProcessRunner implements ProcessRunner
             foreach ($lines as $line) {
                 $line = trim($line);
                 if (!empty($line)) {
-                    $this->userInteraction->write($prefix.' '.$line);
+                    $this->userInteraction->write($prefix . ' ' . $line);
                 }
             }
         };

--- a/src/Cli/IO/InteractiveProcessRunner.php
+++ b/src/Cli/IO/InteractiveProcessRunner.php
@@ -28,7 +28,7 @@ class InteractiveProcessRunner implements ProcessRunner
     {
         $process = new Process($command);
 
-        $this->userInteraction->write('<info>RUN</info> ' . $process->getCommandLine());
+        $this->userInteraction->write('<info>RUN</info> '.$process->getCommandLine());
 
         if ($mustSucceed) {
             $process->setTimeout(null);
@@ -57,7 +57,7 @@ class InteractiveProcessRunner implements ProcessRunner
             foreach ($lines as $line) {
                 $line = trim($line);
                 if (!empty($line)) {
-                    $this->userInteraction->write($prefix . ' ' . $line);
+                    $this->userInteraction->write($prefix.' '.$line);
                 }
             }
         };

--- a/src/Cli/LogsCommand.php
+++ b/src/Cli/LogsCommand.php
@@ -33,7 +33,8 @@ class LogsCommand extends Command
         $this
             ->setName('logs')
             ->setDescription('Follow logs of application containers')
-            ->addArgument('component', InputArgument::OPTIONAL, 'Name of component to follow');
+            ->addArgument('component', InputArgument::OPTIONAL, 'Name of component to follow')
+        ;
     }
 
     /**

--- a/src/Cli/LogsCommand.php
+++ b/src/Cli/LogsCommand.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Process;
 
 class LogsCommand extends Command
 {
@@ -34,8 +33,7 @@ class LogsCommand extends Command
         $this
             ->setName('logs')
             ->setDescription('Follow logs of application containers')
-            ->addArgument('component', InputArgument::OPTIONAL, 'Name of component to follow')
-        ;
+            ->addArgument('component', InputArgument::OPTIONAL, 'Name of component to follow');
     }
 
     /**
@@ -56,7 +54,7 @@ class LogsCommand extends Command
      */
     private function getDockerComposePath()
     {
-        $output = $this->processRunner->run(new Process('which docker-compose'))->getOutput();
+        $output = $this->processRunner->run('which docker-compose')->getOutput();
 
         return trim($output);
     }

--- a/src/Cli/RestartCommand.php
+++ b/src/Cli/RestartCommand.php
@@ -31,7 +31,8 @@ class RestartCommand extends Command
     {
         $this
             ->setName('docker:restart')
-            ->setDescription('Restart Docker');
+            ->setDescription('Restart Docker')
+        ;
     }
 
     /**

--- a/src/Cli/UpCommand.php
+++ b/src/Cli/UpCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class UpCommand extends Command
 {
@@ -24,7 +23,7 @@ class UpCommand extends Command
     private $userInteraction;
 
     /**
-     * @param ProcessRunner   $processRunner
+     * @param ProcessRunner $processRunner
      * @param UserInteraction $userInteraction
      */
     public function __construct(ProcessRunner $processRunner, UserInteraction $userInteraction)
@@ -42,8 +41,7 @@ class UpCommand extends Command
     {
         $this
             ->setName('up')
-            ->setDescription('Start the project')
-        ;
+            ->setDescription('Start the project');
     }
 
     /**
@@ -62,7 +60,7 @@ class UpCommand extends Command
         $this->userInteraction->writeTitle('Starting application containers');
 
         try {
-            $this->processRunner->run(new Process('docker-compose up -d'));
+            $this->processRunner->run('docker-compose up -d');
             $this->userInteraction->writeTitle('Application containers successfully started');
         } catch (ProcessFailedException $e) {
             echo $e->getProcess()->getOutput();

--- a/src/Cli/UpCommand.php
+++ b/src/Cli/UpCommand.php
@@ -41,7 +41,8 @@ class UpCommand extends Command
     {
         $this
             ->setName('up')
-            ->setDescription('Start the project');
+            ->setDescription('Start the project')
+        ;
     }
 
     /**

--- a/src/Compose/Inspector.php
+++ b/src/Compose/Inspector.php
@@ -3,7 +3,6 @@
 namespace Dock\Compose;
 
 use Dock\IO\ProcessRunner;
-use Symfony\Component\Process\Process;
 
 class Inspector
 {
@@ -47,7 +46,9 @@ class Inspector
         $containerName = substr($inspection['Name'], 1);
         $containerConfiguration = $inspection['Config'];
         $imageName = $containerConfiguration['Image'];
-        $exposedPorts = isset($containerConfiguration['ExposedPorts']) ? array_keys($containerConfiguration['ExposedPorts']) : [];
+        $exposedPorts = isset($containerConfiguration['ExposedPorts']) ? array_keys(
+            $containerConfiguration['ExposedPorts']
+        ) : [];
         $componentName = isset($containerConfiguration['Labels']['com.docker.compose.service']) ? $containerConfiguration['Labels']['com.docker.compose.service'] : null;
 
         return new Container(
@@ -69,8 +70,8 @@ class Inspector
     private function getDnsByContainerNameAndImage($containerName, $containerImage)
     {
         return [
-            $containerImage.'.docker',
-            $containerName.'.'.$containerImage.'.docker',
+            $containerImage . '.docker',
+            $containerName . '.' . $containerImage . '.docker',
         ];
     }
 
@@ -82,7 +83,7 @@ class Inspector
     private function inspectContainer($containerId)
     {
         $command = sprintf('docker inspect %s', $containerId);
-        $rawOutput = $this->processRunner->run(new Process($command))->getOutput();
+        $rawOutput = $this->processRunner->run($command)->getOutput();
         $rawOutput = trim($rawOutput);
 
         if (null === ($inspection = json_decode($rawOutput, true))) {
@@ -97,7 +98,7 @@ class Inspector
      */
     private function getRunningContainerIds()
     {
-        $rawOutput = $this->processRunner->run(new Process('docker-compose ps -q'))->getOutput();
+        $rawOutput = $this->processRunner->run('docker-compose ps -q')->getOutput();
         $lines = explode("\n", $rawOutput);
         $containerIds = [];
 

--- a/src/Compose/Inspector.php
+++ b/src/Compose/Inspector.php
@@ -70,8 +70,8 @@ class Inspector
     private function getDnsByContainerNameAndImage($containerName, $containerImage)
     {
         return [
-            $containerImage . '.docker',
-            $containerName . '.' . $containerImage . '.docker',
+            $containerImage.'.docker',
+            $containerName.'.'.$containerImage.'.docker',
         ];
     }
 

--- a/src/Dinghy/Boot2DockerCli.php
+++ b/src/Dinghy/Boot2DockerCli.php
@@ -32,7 +32,7 @@ class Boot2DockerCli
         chmod($scriptPath, 0777);
 
         try {
-            $this->processRunner->run(new Process('sudo '.$scriptPath));
+            $this->processRunner->run('sudo '.$scriptPath);
         } catch (ProcessFailedException $e) {
             return false;
         }
@@ -47,7 +47,7 @@ class Boot2DockerCli
      */
     public function isInstalled()
     {
-        return $this->processRunner->run(new Process('boot2docker version'), false)->isSuccessful();
+        return $this->processRunner->run('boot2docker version', false)->isSuccessful();
     }
 
     /**
@@ -59,7 +59,7 @@ class Boot2DockerCli
      */
     public function getVersion()
     {
-        $process = $this->processRunner->run(new Process('boot2docker version'));
+        $process = $this->processRunner->run('boot2docker version');
 
         return $process->getOutput();
     }

--- a/src/Dinghy/DinghyCli.php
+++ b/src/Dinghy/DinghyCli.php
@@ -4,7 +4,6 @@ namespace Dock\Dinghy;
 
 use Dock\IO\ProcessRunner;
 use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class DinghyCli
 {
@@ -28,7 +27,7 @@ class DinghyCli
      */
     public function start()
     {
-        $this->processRunner->run(new Process('dinghy up --no-proxy'));
+        $this->processRunner->run('dinghy up --no-proxy');
     }
 
     /**
@@ -38,7 +37,7 @@ class DinghyCli
      */
     public function stop()
     {
-        $this->processRunner->run(new Process('dinghy halt'));
+        $this->processRunner->run('dinghy halt');
     }
 
     /**
@@ -46,7 +45,7 @@ class DinghyCli
      */
     public function getVersion()
     {
-        $process = $this->processRunner->run(new Process('dinghy version'));
+        $process = $this->processRunner->run('dinghy version');
 
         return $process->getOutput();
     }
@@ -56,7 +55,7 @@ class DinghyCli
      */
     public function getIp()
     {
-        $process = $this->processRunner->run(new Process('dinghy ip'));
+        $process = $this->processRunner->run('dinghy ip');
         $dinghyIp = $process->getOutput();
 
         return trim($dinghyIp);
@@ -67,7 +66,7 @@ class DinghyCli
      */
     public function isRunning()
     {
-        $process = $this->processRunner->run(new Process('dinghy status'));
+        $process = $this->processRunner->run('dinghy status');
         $output = $process->getOutput();
 
         return strpos($output, 'VM: running') !== false;
@@ -78,6 +77,6 @@ class DinghyCli
      */
     public function isInstalled()
     {
-        return $this->processRunner->run(new Process('dinghy version'), false)->isSuccessful();
+        return $this->processRunner->run('dinghy version', false)->isSuccessful();
     }
 }

--- a/src/IO/ProcessRunner.php
+++ b/src/IO/ProcessRunner.php
@@ -7,10 +7,10 @@ use Symfony\Component\Process\Process;
 interface ProcessRunner
 {
     /**
-     * @param Process $process
-     * @param bool    $mustSucceed
+     * @param $command
+     * @param bool $mustSucceed
      *
      * @return Process
      */
-    public function run(Process $process, $mustSucceed = true);
+    public function run($command, $mustSucceed = true);
 }

--- a/src/IO/ProcessRunner.php
+++ b/src/IO/ProcessRunner.php
@@ -7,7 +7,7 @@ use Symfony\Component\Process\Process;
 interface ProcessRunner
 {
     /**
-     * @param $command
+     * @param string $command
      * @param bool $mustSucceed
      *
      * @return Process

--- a/src/IO/SilentProcessRunner.php
+++ b/src/IO/SilentProcessRunner.php
@@ -9,8 +9,10 @@ class SilentProcessRunner implements ProcessRunner
     /**
      * {@inheritdoc}
      */
-    public function run(Process $process, $mustSucceed = true)
+    public function run($command, $mustSucceed = true)
     {
+        $process = new Process($command);
+
         if ($mustSucceed) {
             $process->setTimeout(null);
 

--- a/src/Installer/DNS/DnsDock.php
+++ b/src/Installer/DNS/DnsDock.php
@@ -48,10 +48,10 @@ class DnsDock extends InstallerTask implements DependentChainProcessInterface
         }
 
         if (!$this->dnsDockerIsInStartupConfiguration()) {
-            $bootScript = 'sleep 5' . PHP_EOL .
-                'docker start dnsdock || docker run -d -v /var/run/docker.sock:/var/run/docker.sock --name dnsdock -p 172.17.42.1:53:53/udp tonistiigi/dnsdock' . PHP_EOL;
+            $bootScript = 'sleep 5'.PHP_EOL .
+                'docker start dnsdock || docker run -d -v /var/run/docker.sock:/var/run/docker.sock --name dnsdock -p 172.17.42.1:53:53/udp tonistiigi/dnsdock'.PHP_EOL;
 
-            $this->sshExec->run('echo "' . $bootScript . '" | sudo tee -a /var/lib/boot2docker/bootlocal.sh');
+            $this->sshExec->run('echo "'.$bootScript.'" | sudo tee -a /var/lib/boot2docker/bootlocal.sh');
             $needDinghyRestart = true;
         }
 

--- a/src/Installer/DNS/DnsDock.php
+++ b/src/Installer/DNS/DnsDock.php
@@ -57,13 +57,13 @@ class DnsDock extends InstallerTask implements DependentChainProcessInterface
 
         // Configure host machine resolution
         $processRunner = $context->getProcessRunner();
-        $processRunner->run(new Process('sudo mkdir -p /etc/resolver'));
-        $processRunner->run(new Process('echo "nameserver 172.17.42.1" | sudo tee /etc/resolver/docker'));
+        $processRunner->run('sudo mkdir -p /etc/resolver');
+        $processRunner->run('echo "nameserver 172.17.42.1" | sudo tee /etc/resolver/docker');
 
         // Restart dinghy
         if ($needDinghyRestart) {
             $userInteraction->writeTitle('Restarting Dinghy');
-            $processRunner->run(new Process('dinghy restart'));
+            $processRunner->run('dinghy restart');
         }
     }
 

--- a/src/Installer/DNS/DockerRouting.php
+++ b/src/Installer/DNS/DockerRouting.php
@@ -87,7 +87,7 @@ class DockerRouting extends InstallerTask implements DependentChainProcessInterf
             return;
         }
 
-        $source = __DIR__ . '/fixtures/com.docker.route.plist';
+        $source = __DIR__.'/fixtures/com.docker.route.plist';
         $dockerRouteFileContents = file_get_contents($source);
         $dockerRouteFileContents = str_replace('__DINGHY_IP__', $dinghyIp, $dockerRouteFileContents);
 

--- a/src/Installer/DNS/DockerRouting.php
+++ b/src/Installer/DNS/DockerRouting.php
@@ -9,7 +9,6 @@ use Dock\IO\ProcessRunner;
 use Dock\IO\UserInteraction;
 use SRIO\ChainOfResponsibility\DependentChainProcessInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class DockerRouting extends InstallerTask implements DependentChainProcessInterface
 {
@@ -66,8 +65,7 @@ class DockerRouting extends InstallerTask implements DependentChainProcessInterf
     private function configureRouting($dinghyIp, ProcessRunner $processRunner, UserInteraction $userInteraction)
     {
         try {
-            $process = new Process(sprintf('sudo route -n add 172.17.0.0/16 %s', $dinghyIp));
-            $processRunner->run($process);
+            $processRunner->run(sprintf('sudo route -n add 172.17.0.0/16 %s', $dinghyIp));
         } catch (ProcessFailedException $e) {
             if (strpos($e->getProcess()->getErrorOutput(), 'File exists') !== false) {
                 $userInteraction->writeTitle('Routing already configured');
@@ -96,17 +94,7 @@ class DockerRouting extends InstallerTask implements DependentChainProcessInterf
         $temporaryFile = tempnam(sys_get_temp_dir(), 'DockerInstaller');
         file_put_contents($temporaryFile, $dockerRouteFileContents);
 
-        $processRunner->run(
-            new Process(sprintf(
-                'sudo cp %s /Library/LaunchDaemons/com.docker.route.plist',
-                $temporaryFile
-            ))
-        );
-
-        $processRunner->run(
-            new Process(
-                'sudo launchctl load /Library/LaunchDaemons/com.docker.route.plist'
-            )
-        );
+        $processRunner->run(sprintf('sudo cp %s /Library/LaunchDaemons/com.docker.route.plist', $temporaryFile));
+        $processRunner->run('sudo launchctl load /Library/LaunchDaemons/com.docker.route.plist');
     }
 }

--- a/src/Installer/Docker/Dinghy.php
+++ b/src/Installer/Docker/Dinghy.php
@@ -58,12 +58,12 @@ class Dinghy extends InstallerTask implements DependentChainProcessInterface
 
     private function changeDinghyDnsResolverNamespace()
     {
-        $process = $this->processRunner->run(new Process('dinghy version'));
+        $process = $this->processRunner->run('dinghy version');
         $dinghyVersionOutput = $process->getOutput();
         $dinghyVersion = substr(trim($dinghyVersionOutput), strlen('Dinghy '));
         $dnsMasqConfiguration = '/usr/local/Cellar/dinghy/' . $dinghyVersion . '/cli/dinghy/dnsmasq.rb';
 
-        $process = new Process('sed -i \'\' \'s/docker/zzz-dinghy/\' ' . $dnsMasqConfiguration);
+        $process = 'sed -i \'\' \'s/docker/zzz-dinghy/\' ' . $dnsMasqConfiguration;
         $this->processRunner->run($process);
     }
 
@@ -108,7 +108,7 @@ class Dinghy extends InstallerTask implements DependentChainProcessInterface
 
         $this->userInteraction->writeTitle('Installing Dinghy');
         $this->processRunner->run(
-            new Process('brew install https://github.com/codekitchen/dinghy/raw/latest/dinghy.rb')
+            'brew install https://github.com/codekitchen/dinghy/raw/latest/dinghy.rb'
         );
         $this->userInteraction->writeTitle('Successfully installed Dinghy');
     }

--- a/src/Installer/Docker/Dinghy.php
+++ b/src/Installer/Docker/Dinghy.php
@@ -61,9 +61,9 @@ class Dinghy extends InstallerTask implements DependentChainProcessInterface
         $process = $this->processRunner->run('dinghy version');
         $dinghyVersionOutput = $process->getOutput();
         $dinghyVersion = substr(trim($dinghyVersionOutput), strlen('Dinghy '));
-        $dnsMasqConfiguration = '/usr/local/Cellar/dinghy/' . $dinghyVersion . '/cli/dinghy/dnsmasq.rb';
+        $dnsMasqConfiguration = '/usr/local/Cellar/dinghy/'.$dinghyVersion.'/cli/dinghy/dnsmasq.rb';
 
-        $process = 'sed -i \'\' \'s/docker/zzz-dinghy/\' ' . $dnsMasqConfiguration;
+        $process = 'sed -i \'\' \'s/docker/zzz-dinghy/\' '.$dnsMasqConfiguration;
         $this->processRunner->run($process);
     }
 

--- a/src/Installer/Docker/EnvironmentVariables.php
+++ b/src/Installer/Docker/EnvironmentVariables.php
@@ -41,7 +41,7 @@ class EnvironmentVariables extends InstallerTask implements DependentChainProces
         $userHome = getenv('HOME');
         $environmentVariables = [
             new EnvironmentVariable('DOCKER_HOST', 'tcp://127.0.0.1:2376'),
-            new EnvironmentVariable('DOCKER_CERT_PATH', $userHome . '/.dinghy/certs'),
+            new EnvironmentVariable('DOCKER_CERT_PATH', $userHome.'/.dinghy/certs'),
             new EnvironmentVariable('DOCKER_TLS_VERIFY', '1'),
         ];
 

--- a/src/Installer/SoftwareInstallTask.php
+++ b/src/Installer/SoftwareInstallTask.php
@@ -3,7 +3,6 @@
 namespace Dock\Installer;
 
 use SRIO\ChainOfResponsibility\NamedChainProcessInterface;
-use Symfony\Component\Process\Process;
 
 abstract class SoftwareInstallTask extends InstallerTask implements NamedChainProcessInterface
 {
@@ -15,18 +14,11 @@ abstract class SoftwareInstallTask extends InstallerTask implements NamedChainPr
         $processRunner = $context->getProcessRunner();
         $userInteraction = $context->getUserInteraction();
 
-        $versionCommand = $this->getVersionCommand();
-        $versionProcess = new Process($versionCommand);
-        $processRunner->run($versionProcess, false);
-
-        if ($versionProcess->isSuccessful()) {
+        if ($processRunner->run($this->getVersionCommand(), false)->isSuccessful()) {
             $userInteraction->write(sprintf('"%s" is already installed', $this->getName()));
         } else {
-            $installCommand = $this->getInstallCommand();
-            $installProcess = new Process($installCommand);
-
             $userInteraction->write(sprintf('Installing "%s"', $this->getName()));
-            $processRunner->run($installProcess);
+            $processRunner->run($this->getInstallCommand());
             $userInteraction->write(sprintf('"%s" successfully installed', $this->getName()));
         }
     }

--- a/src/Installer/System/PhpSsh.php
+++ b/src/Installer/System/PhpSsh.php
@@ -54,12 +54,12 @@ class PhpSsh extends InstallerTask implements DependentChainProcessInterface
                 if (!$this->hasHomebrewPackage($processRunner, $package)) {
                     $userInteraction->write(sprintf('Package "%s" not found, tapping default PHP brews', $package));
 
-                    $processRunner->run(new Process('brew tap homebrew/dupes'));
-                    $processRunner->run(new Process('brew tap homebrew/versions'));
-                    $processRunner->run(new Process('brew tap homebrew/homebrew-php'));
+                    $processRunner->run('brew tap homebrew/dupes');
+                    $processRunner->run('brew tap homebrew/versions');
+                    $processRunner->run('brew tap homebrew/homebrew-php');
                 }
 
-                $processRunner->run(new Process('brew install '.$package));
+                $processRunner->run('brew install '.$package);
             }
 
             $userInteraction->write('Please re-run this installation script to have enabled PHP-SSH2 extension');
@@ -89,7 +89,7 @@ class PhpSsh extends InstallerTask implements DependentChainProcessInterface
      */
     private function hasHomebrewPackage(ProcessRunner $processRunner, $package)
     {
-        return $processRunner->run(new Process('brew install --dry-run '.$package), false)->isSuccessful();
+        return $processRunner->run('brew install --dry-run '.$package, false)->isSuccessful();
     }
 
     /**

--- a/src/System/Environ/BashEnvironManipulator.php
+++ b/src/System/Environ/BashEnvironManipulator.php
@@ -37,7 +37,7 @@ class BashEnvironManipulator implements EnvironManipulator
             $this->file
         );
 
-        $this->processRunner->run(new Process($command));
+        $this->processRunner->run($command);
     }
 
     /**
@@ -46,7 +46,7 @@ class BashEnvironManipulator implements EnvironManipulator
     public function has(EnvironmentVariable $environmentVariable)
     {
         $process = $this->processRunner->run(
-            new Process(sprintf('grep %s %s', $environmentVariable->getName(), $this->file)),
+            sprintf('grep %s %s', $environmentVariable->getName(), $this->file),
             false
         );
 


### PR DESCRIPTION
May be a controversial one :) 

Everything that wants to run a command using a process runner has to instantiate a process object to pass to the process manager. This moves that inside the process runners and lets the calling code just pass the command as a string. 
