### PR TITLE
Make the context a facade instead of getting things out of it

### DIFF
--- a/src/Installer/DNS/DnsDock.php
+++ b/src/Installer/DNS/DnsDock.php
@@ -28,7 +28,7 @@ class DnsDock extends InstallerTask implements DependentChainProcessInterface
      */
     public function run(InstallContext $context)
     {
-        $context->getUserInteraction()->writeTitle('Configure DNS resolution for Docker containers');
+        $context->writeTitle('Configure DNS resolution for Docker containers');
 
         $needDinghyRestart = $this->configureVirtualMachine();
         $this->configureHostMachineResolution($context);
@@ -114,9 +114,8 @@ class DnsDock extends InstallerTask implements DependentChainProcessInterface
      */
     private function configureHostMachineResolution(InstallContext $context)
     {
-        $processRunner = $context->getProcessRunner();
-        $processRunner->run('sudo mkdir -p /etc/resolver');
-        $processRunner->run('echo "nameserver 172.17.42.1" | sudo tee /etc/resolver/docker');
+        $context->run('sudo mkdir -p /etc/resolver');
+        $context->run('echo "nameserver 172.17.42.1" | sudo tee /etc/resolver/docker');
     }
 
     /**
@@ -124,7 +123,7 @@ class DnsDock extends InstallerTask implements DependentChainProcessInterface
      */
     private function restartDinghy(InstallContext $context)
     {
-        $context->getUserInteraction()->writeTitle('Restarting Dinghy');
-        $context->getProcessRunner()->run('dinghy restart');
+        $context->writeTitle('Restarting Dinghy');
+        $context->run('dinghy restart');
     }
 }

--- a/src/Installer/Docker/EnvironmentVariables.php
+++ b/src/Installer/Docker/EnvironmentVariables.php
@@ -28,16 +28,13 @@ class EnvironmentVariables extends InstallerTask implements DependentChainProces
      */
     public function run(InstallContext $context)
     {
-        $userInteraction = $context->getUserInteraction();
         if ($this->isEnvironmentConfigured()) {
-            $userInteraction->write('Environment variables are already configured');
+            $context->write('Environment variables are already configured');
 
             return;
         }
 
-        $userInteraction->writeTitle('Setting up dinghy environment variables');
-        $processRunner = $context->getProcessRunner();
-
+        $context->writeTitle('Setting up dinghy environment variables');
         $userHome = getenv('HOME');
         $environmentVariables = [
             new EnvironmentVariable('DOCKER_HOST', 'tcp://127.0.0.1:2376'),
@@ -45,7 +42,7 @@ class EnvironmentVariables extends InstallerTask implements DependentChainProces
             new EnvironmentVariable('DOCKER_TLS_VERIFY', '1'),
         ];
 
-        $environManipulator = $this->environManipulatorFactory->getSystemManipulator($processRunner);
+        $environManipulator = $this->environManipulatorFactory->getSystemManipulator($context->getProcessRunner());
 
         foreach ($environmentVariables as $environmentVariable) {
             if (!$environManipulator->has($environmentVariable)) {

--- a/src/Installer/InstallContext.php
+++ b/src/Installer/InstallContext.php
@@ -5,8 +5,10 @@ namespace Dock\Installer;
 use Dock\IO\ProcessRunner;
 use Dock\IO\UserInteraction;
 use SRIO\ChainOfResponsibility\ChainContext;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Process\Process;
 
-class InstallContext implements ChainContext
+class InstallContext implements ChainContext, ProcessRunner, UserInteraction
 {
     /**
      * @var ProcessRunner
@@ -19,7 +21,7 @@ class InstallContext implements ChainContext
     private $userInteraction;
 
     /**
-     * @param ProcessRunner   $processRunner
+     * @param ProcessRunner $processRunner
      * @param UserInteraction $userInteraction
      */
     public function __construct(ProcessRunner $processRunner, UserInteraction $userInteraction)
@@ -29,18 +31,46 @@ class InstallContext implements ChainContext
     }
 
     /**
-     * @return ProcessRunner
+     * @param string $command
+     * @param bool $mustSucceed
+     * @return Process
+     */
+    public function run($command, $mustSucceed = true)
+    {
+        return $this->processRunner->run($command, $mustSucceed);
+    }
+
+    /**
+     * @param string $string
+     */
+    public function writeTitle($string)
+    {
+        $this->userInteraction->writeTitle($string);
+    }
+
+    /**
+     * @param string $string
+     */
+    public function write($string)
+    {
+        $this->userInteraction->write($string);
+    }
+
+    /**
+     * @param Question $question
+     *
+     * @return string
+     */
+    public function ask(Question $question)
+    {
+        return $this->userInteraction->ask($question);
+    }
+
+    /**
+     * @return \Dock\IO\ProcessRunner
      */
     public function getProcessRunner()
     {
         return $this->processRunner;
-    }
-
-    /**
-     * @return UserInteraction
-     */
-    public function getUserInteraction()
-    {
-        return $this->userInteraction;
     }
 }

--- a/src/Installer/SoftwareInstallTask.php
+++ b/src/Installer/SoftwareInstallTask.php
@@ -11,15 +11,12 @@ abstract class SoftwareInstallTask extends InstallerTask implements NamedChainPr
      */
     public function run(InstallContext $context)
     {
-        $processRunner = $context->getProcessRunner();
-        $userInteraction = $context->getUserInteraction();
-
-        if ($processRunner->run($this->getVersionCommand(), false)->isSuccessful()) {
-            $userInteraction->write(sprintf('"%s" is already installed', $this->getName()));
+        if ($context->run($this->getVersionCommand(), false)->isSuccessful()) {
+            $context->write(sprintf('"%s" is already installed', $this->getName()));
         } else {
-            $userInteraction->write(sprintf('Installing "%s"', $this->getName()));
-            $processRunner->run($this->getInstallCommand());
-            $userInteraction->write(sprintf('"%s" successfully installed', $this->getName()));
+            $context->write(sprintf('Installing "%s"', $this->getName()));
+            $context->run($this->getInstallCommand());
+            $context->write(sprintf('"%s" successfully installed', $this->getName()));
         }
     }
 

--- a/src/Installer/System/PhpSsh.php
+++ b/src/Installer/System/PhpSsh.php
@@ -4,10 +4,8 @@ namespace Dock\Installer\System;
 
 use Dock\Installer\InstallContext;
 use Dock\Installer\InstallerTask;
-use Dock\IO\ProcessRunner;
 use SRIO\ChainOfResponsibility\DependentChainProcessInterface;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Process\Process;
 
 class PhpSsh extends InstallerTask implements DependentChainProcessInterface
 {
@@ -32,27 +30,29 @@ class PhpSsh extends InstallerTask implements DependentChainProcessInterface
      */
     public function run(InstallContext $context)
     {
-        $userInteraction = $context->getUserInteraction();
-        $userInteraction->writeTitle('Checking PHP SSH2 extension');
+        $context->writeTitle('Checking PHP SSH2 extension');
 
         if (!$this->sshExtensionInstalled()) {
-            $userInteraction->write('PHP SSH2 extension is required.');
+            $context->write('PHP SSH2 extension is required.');
 
             $defaultPhpVersion = $this->guessSsh2PhpPackage();
             $question = new Question(
-                sprintf('Which homebrew package do you want to install (default "%s") ? ("n" for nothing)', $defaultPhpVersion),
+                sprintf(
+                    'Which homebrew package do you want to install (default "%s") ? ("n" for nothing)',
+                    $defaultPhpVersion
+                ),
                 $defaultPhpVersion
             );
-            $package = $userInteraction->ask($question);
+            $package = $context->ask($question);
 
             if ($package == 'n') {
-                $userInteraction->write('Skipping PHP SSH2 extension installation, do it yourself.');
+                $context->write('Skipping PHP SSH2 extension installation, do it yourself.');
             } else {
                 $processRunner = $context->getProcessRunner();
 
                 // Check if the package is known
-                if (!$this->hasHomebrewPackage($processRunner, $package)) {
-                    $userInteraction->write(sprintf('Package "%s" not found, tapping default PHP brews', $package));
+                if (!$this->hasHomebrewPackage($context, $package)) {
+                    $context->write(sprintf('Package "%s" not found, tapping default PHP brews', $package));
 
                     $processRunner->run('brew tap homebrew/dupes');
                     $processRunner->run('brew tap homebrew/versions');
@@ -62,7 +62,7 @@ class PhpSsh extends InstallerTask implements DependentChainProcessInterface
                 $processRunner->run('brew install '.$package);
             }
 
-            $userInteraction->write('Please re-run this installation script to have enabled PHP-SSH2 extension');
+            $context->write('Please re-run this installation script to have enabled PHP-SSH2 extension');
 
             exit(1);
         }
@@ -82,14 +82,13 @@ class PhpSsh extends InstallerTask implements DependentChainProcessInterface
     }
 
     /**
-     * @param ProcessRunner $processRunner
-     * @param string        $package
-     *
+     * @param InstallContext $context
+     * @param string $package
      * @return bool
      */
-    private function hasHomebrewPackage(ProcessRunner $processRunner, $package)
+    private function hasHomebrewPackage(InstallContext $context, $package)
     {
-        return $processRunner->run('brew install --dry-run '.$package, false)->isSuccessful();
+        return $context->run('brew install --dry-run '.$package, false)->isSuccessful();
     }
 
     /**


### PR DESCRIPTION
Not sure about this one but there a lot of calls to `$context->getUserInteraction()` and `$context->getProcessRunner()` with only a few methods called on the returned objects. This gets the context to delegate to those objects rather than return them.
