### PR TITLE
Start & stop commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ The following commands are available:
 
 ### Project commands
 
-- [`up` command](docs/cmd-up.md) starts the Docker environment for the project.
+- [`start` command](docs/cmd-start.md) starts the Docker environment for the project.
+- [`stop` command](docs/cmd-stop.md) stops the running Docker containers of the project.
 - [`ps` command](docs/cmd-ps.md) list all the project containers if any.
 - [`logs` command](docs/cmd-logs.md) follows the logs of all or a given container.
 

--- a/app/container.php
+++ b/app/container.php
@@ -43,7 +43,7 @@ $container['command.selfupdate'] = function () {
 };
 
 $container['command.install'] = function ($c) {
-    return new InstallCommand($c['installer.docker']);
+    return new InstallCommand($c['installer.docker'], $c['process.silent_runner']);
 };
 
 $container['console.user_interaction'] = function ($c) {
@@ -97,13 +97,13 @@ $container['command.start'] = function ($c) {
     return new StartCommand($c['process.silent_runner'], $c['console.user_interaction']);
 };
 $container['command.stop'] = function ($c) {
-    return new StopCommand($c['compose.executable_finder'], $c['console.user_interaction']);
+    return new StopCommand($c['compose.executable_finder'], $c['console.user_interaction'], $c['process.silent_runner']);
 };
 $container['command.ps'] = function ($c) {
     return new PsCommand(new Inspector($c['process.silent_runner']));
 };
 $container['command.logs'] = function ($c) {
-    return new LogsCommand($c['compose.executable_finder']);
+    return new LogsCommand($c['compose.executable_finder'], $c['process.silent_runner']);
 };
 $container['event_dispatcher'] = function () {
     return new EventDispatcher();

--- a/app/container.php
+++ b/app/container.php
@@ -7,7 +7,9 @@ use Dock\Cli\LogsCommand;
 use Dock\Cli\PsCommand;
 use Dock\Cli\RestartCommand;
 use Dock\Cli\SelfUpdateCommand;
-use Dock\Cli\UpCommand;
+use Dock\Cli\StartCommand;
+use Dock\Cli\StopCommand;
+use Dock\Compose\ComposeExecutableFinder;
 use Dock\Compose\Inspector;
 use Dock\Dinghy\Boot2DockerCli;
 use Dock\Dinghy\DinghyCli;
@@ -64,7 +66,9 @@ $container['process.interactive_runner'] = function ($c) {
 $container['process.silent_runner'] = function () {
     return new SilentProcessRunner();
 };
-
+$container['compose.executable_finder'] = function () {
+    return new ComposeExecutableFinder();
+};
 $container['installer.docker'] = function ($c) {
     return new DockerInstaller(
         new \SRIO\ChainOfResponsibility\ChainBuilder([
@@ -89,14 +93,17 @@ $container['command.restart'] = function ($c) {
     return new RestartCommand(new DinghyCli($c['process.interactive_runner']));
 };
 
-$container['command.up'] = function ($c) {
-    return new UpCommand($c['process.silent_runner'], $c['console.user_interaction']);
+$container['command.start'] = function ($c) {
+    return new StartCommand($c['process.silent_runner'], $c['console.user_interaction']);
+};
+$container['command.stop'] = function ($c) {
+    return new StopCommand($c['compose.executable_finder'], $c['console.user_interaction']);
 };
 $container['command.ps'] = function ($c) {
     return new PsCommand(new Inspector($c['process.silent_runner']));
 };
 $container['command.logs'] = function ($c) {
-    return new LogsCommand($c['process.interactive_runner']);
+    return new LogsCommand($c['compose.executable_finder']);
 };
 $container['event_dispatcher'] = function () {
     return new EventDispatcher();
@@ -114,7 +121,8 @@ $container['application'] = function ($c) {
             $c['command.selfupdate'],
             $c['command.install'],
             $c['command.restart'],
-            $c['command.up'],
+            $c['command.start'],
+            $c['command.stop'],
             $c['command.ps'],
             $c['command.logs'],
         )

--- a/docs/cmd-start.md
+++ b/docs/cmd-start.md
@@ -1,9 +1,9 @@
-# `up` command
+# `start` command
 
 This starts up a docker-compose project.
 
 ## Usage
 
 ```
-dock-cli up
+dock-cli start
 ```

--- a/docs/cmd-stop.md
+++ b/docs/cmd-stop.md
@@ -1,6 +1,6 @@
 # `stop` command
 
-This stop running containers of a docker-compose-based project.
+This stops running containers of a docker-compose-based project.
 
 ## Usage
 

--- a/docs/cmd-stop.md
+++ b/docs/cmd-stop.md
@@ -1,0 +1,9 @@
+# `stop` command
+
+This stop running containers of a docker-compose-based project.
+
+## Usage
+
+```
+dock-cli stop
+```

--- a/src/Cli/IO/InteractiveProcessRunner.php
+++ b/src/Cli/IO/InteractiveProcessRunner.php
@@ -42,6 +42,20 @@ class InteractiveProcessRunner implements ProcessRunner
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function followsUpWith($command, array $arguments = [])
+    {
+        $this->userInteraction->write(sprintf(
+            '<info>RUN</info> %s %s',
+            $command,
+            implode(' ', $arguments)
+        ));
+
+        pcntl_exec($command, $arguments);
+    }
+
+    /**
      * @param bool $highlightErrors
      *
      * @return callable

--- a/src/Cli/InstallCommand.php
+++ b/src/Cli/InstallCommand.php
@@ -3,6 +3,7 @@
 namespace Dock\Cli;
 
 use Dock\Installer\DockerInstaller;
+use Dock\IO\ProcessRunner;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -15,13 +16,20 @@ class InstallCommand extends Command
     private $dockerInstaller;
 
     /**
-     * @param DockerInstaller $dockerInstaller
+     * @var ProcessRunner
      */
-    public function __construct(DockerInstaller $dockerInstaller)
+    private $processRunner;
+
+    /**
+     * @param DockerInstaller $dockerInstaller
+     * @param ProcessRunner $processRunner
+     */
+    public function __construct(DockerInstaller $dockerInstaller, ProcessRunner $processRunner)
     {
         parent::__construct();
 
         $this->dockerInstaller = $dockerInstaller;
+        $this->processRunner = $processRunner;
     }
 
     /**
@@ -41,7 +49,6 @@ class InstallCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->dockerInstaller->install();
-
-        pcntl_exec(getenv('SHELL'));
+        $this->processRunner->followsUpWith(getenv('SHELL'));
     }
 }

--- a/src/Cli/LogsCommand.php
+++ b/src/Cli/LogsCommand.php
@@ -15,15 +15,21 @@ class LogsCommand extends Command
      * @var ComposeExecutableFinder
      */
     private $composeExecutableFinder;
+    /**
+     * @var ProcessRunner
+     */
+    private $processRunner;
 
     /**
      * @param ComposeExecutableFinder $composeExecutableFinder
+     * @param ProcessRunner $processRunner
      */
-    public function __construct(ComposeExecutableFinder $composeExecutableFinder)
+    public function __construct(ComposeExecutableFinder $composeExecutableFinder, ProcessRunner $processRunner)
     {
         parent::__construct();
 
         $this->composeExecutableFinder = $composeExecutableFinder;
+        $this->processRunner = $processRunner;
     }
 
     /**
@@ -48,6 +54,6 @@ class LogsCommand extends Command
             $composeLogsArguments[] = $component;
         }
 
-        pcntl_exec($this->composeExecutableFinder->find(), $composeLogsArguments);
+        $this->processRunner->followsUpWith($this->composeExecutableFinder->find(), $composeLogsArguments);
     }
 }

--- a/src/Cli/StartCommand.php
+++ b/src/Cli/StartCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
-class UpCommand extends Command
+class StartCommand extends Command
 {
     /**
      * @var ProcessRunner
@@ -40,7 +40,7 @@ class UpCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('up')
+            ->setName('start')
             ->setDescription('Start the project')
         ;
     }
@@ -59,15 +59,8 @@ class UpCommand extends Command
         }
 
         $this->userInteraction->writeTitle('Starting application containers');
-
-        try {
-            $this->processRunner->run('docker-compose up -d');
-            $this->userInteraction->writeTitle('Application containers successfully started');
-        } catch (ProcessFailedException $e) {
-            echo $e->getProcess()->getOutput();
-
-            return 1;
-        }
+        $this->processRunner->run('docker-compose up -d');
+        $this->userInteraction->writeTitle('Application containers successfully started');
 
         return $this->getApplication()->run(
             new ArrayInput(['command' => 'ps']),

--- a/src/Cli/StopCommand.php
+++ b/src/Cli/StopCommand.php
@@ -4,13 +4,20 @@ namespace Dock\Cli;
 
 use Dock\Compose\ComposeExecutableFinder;
 use Dock\IO\ProcessRunner;
+use Dock\IO\UserInteraction;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 
-class LogsCommand extends Command
+class StopCommand extends Command
 {
+    /**
+     * @var UserInteraction
+     */
+    private $userInteraction;
+
     /**
      * @var ComposeExecutableFinder
      */
@@ -18,11 +25,13 @@ class LogsCommand extends Command
 
     /**
      * @param ComposeExecutableFinder $composeExecutableFinder
+     * @param UserInteraction $userInteraction
      */
-    public function __construct(ComposeExecutableFinder $composeExecutableFinder)
+    public function __construct(ComposeExecutableFinder $composeExecutableFinder, UserInteraction $userInteraction)
     {
         parent::__construct();
 
+        $this->userInteraction = $userInteraction;
         $this->composeExecutableFinder = $composeExecutableFinder;
     }
 
@@ -32,9 +41,8 @@ class LogsCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('logs')
-            ->setDescription('Follow logs of application containers')
-            ->addArgument('component', InputArgument::OPTIONAL, 'Name of component to follow')
+            ->setName('stop')
+            ->setDescription('Stop the project')
         ;
     }
 
@@ -43,11 +51,8 @@ class LogsCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $composeLogsArguments = ['logs'];
-        if (null !== ($component = $input->getArgument('component'))) {
-            $composeLogsArguments[] = $component;
-        }
+        $this->userInteraction->writeTitle('Stopping application containers');
 
-        pcntl_exec($this->composeExecutableFinder->find(), $composeLogsArguments);
+        pcntl_exec($this->composeExecutableFinder->find(), ['stop']);
     }
 }

--- a/src/Cli/StopCommand.php
+++ b/src/Cli/StopCommand.php
@@ -24,15 +24,22 @@ class StopCommand extends Command
     private $composeExecutableFinder;
 
     /**
+     * @var ProcessRunner
+     */
+    private $processRunner;
+
+    /**
      * @param ComposeExecutableFinder $composeExecutableFinder
      * @param UserInteraction $userInteraction
+     * @param ProcessRunner $processRunner
      */
-    public function __construct(ComposeExecutableFinder $composeExecutableFinder, UserInteraction $userInteraction)
+    public function __construct(ComposeExecutableFinder $composeExecutableFinder, UserInteraction $userInteraction, ProcessRunner $processRunner)
     {
         parent::__construct();
 
         $this->userInteraction = $userInteraction;
         $this->composeExecutableFinder = $composeExecutableFinder;
+        $this->processRunner = $processRunner;
     }
 
     /**
@@ -53,6 +60,6 @@ class StopCommand extends Command
     {
         $this->userInteraction->writeTitle('Stopping application containers');
 
-        pcntl_exec($this->composeExecutableFinder->find(), ['stop']);
+        $this->processRunner->followsUpWith($this->composeExecutableFinder->find(), ['stop']);
     }
 }

--- a/src/Compose/ComposeExecutableFinder.php
+++ b/src/Compose/ComposeExecutableFinder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Dock\Compose;
+
+use Symfony\Component\Process\ExecutableFinder;
+
+class ComposeExecutableFinder
+{
+    /**
+     * @var ExecutableFinder
+     */
+    private $executableFinder;
+
+    public function __construct()
+    {
+        $this->executableFinder = new ExecutableFinder();
+    }
+
+    /**
+     * @return string
+     */
+    public function find()
+    {
+        if (null === ($executable = $this->executableFinder->find('docker-compose'))) {
+            throw new \RuntimeException('Unable to find docker-compose binary');
+        }
+
+        return $executable;
+    }
+}

--- a/src/Compose/ComposeExecutableFinder.php
+++ b/src/Compose/ComposeExecutableFinder.php
@@ -22,7 +22,10 @@ class ComposeExecutableFinder
     public function find()
     {
         if (null === ($executable = $this->executableFinder->find('docker-compose'))) {
-            throw new \RuntimeException('Unable to find docker-compose binary');
+            throw new \RuntimeException(
+                'Unable to find docker-compose binary. '.
+                'You should run `docker:install` to set up your Docker environment'
+            );
         }
 
         return $executable;

--- a/src/IO/ProcessRunner.php
+++ b/src/IO/ProcessRunner.php
@@ -13,4 +13,10 @@ interface ProcessRunner
      * @return Process
      */
     public function run($command, $mustSucceed = true);
+
+    /**
+     * @param string $command
+     * @param array $arguments
+     */
+    public function followsUpWith($command, array $arguments = []);
 }

--- a/src/IO/SilentProcessRunner.php
+++ b/src/IO/SilentProcessRunner.php
@@ -23,4 +23,12 @@ class SilentProcessRunner implements ProcessRunner
 
         return $process;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function followsUpWith($command, array $arguments = [])
+    {
+        pcntl_exec($command, $arguments);
+    }
 }


### PR DESCRIPTION
This PR contains two things:
- It changes the name of the `up` command to `start`. It looks like to have some confusion about what the `up` command is doing, and as it's actually just starting the containers, IMO it should be named like that.
- Introduce a `stop` command that stop the running containers
