### PR TITLE
Behat suite for PS Command using stubbed infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+/tmp

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,4 @@
+build:
+  environment:
+    php:
+      version: 5.6.9

--- a/app/container.php
+++ b/app/container.php
@@ -10,10 +10,12 @@ use Dock\Cli\SelfUpdateCommand;
 use Dock\Cli\StartCommand;
 use Dock\Cli\StopCommand;
 use Dock\Compose\ComposeExecutableFinder;
-use Dock\Compose\Inspector;
+use Dock\Containers\ConfiguredContainers;
 use Dock\Dinghy\Boot2DockerCli;
 use Dock\Dinghy\DinghyCli;
 use Dock\Dinghy\SshClient;
+use Dock\Docker\ContainerDetails;
+use Dock\DockerCompose\ConfiguredContainerIds;
 use Dock\Installer\DNS\DnsDock;
 use Dock\Installer\DNS\DockerRouting;
 use Dock\Installer\Docker\Dinghy;
@@ -100,8 +102,18 @@ $container['command.stop'] = function ($c) {
     return new StopCommand($c['compose.executable_finder'], $c['console.user_interaction'], $c['process.silent_runner']);
 };
 $container['command.ps'] = function ($c) {
-    return new PsCommand(new Inspector($c['process.silent_runner']));
+    return new PsCommand(new ConfiguredContainers(
+        $c['containers.configured_container_ids'],
+        $c['containers.container_details']
+    ));
 };
+$container['containers.configured_container_ids'] = function ($c) {
+    return new ConfiguredContainerIds($c['process.silent_runner']);
+};
+$container['containers.container_details'] = function ($c) {
+    return new ContainerDetails($c['process.silent_runner']);
+};
+
 $container['command.logs'] = function ($c) {
     return new LogsCommand($c['compose.executable_finder'], $c['process.silent_runner']);
 };

--- a/behat.yml
+++ b/behat.yml
@@ -2,7 +2,12 @@ default:
   suites:
     application:
       contexts: [ ApplicationTesterContext ]
-    smoke: false
-
   gherkin:
     filters: { tags: ~@wip }
+
+
+smoke:
+  suites:
+    smoke:
+      contexts: [ SmokeContext ]
+      filters: { tags: @smoke }

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,8 @@
+default:
+  suites:
+    application:
+      contexts: [ ApplicationTesterContext ]
+    smoke: false
+
+  gherkin:
+    filters: { tags: ~@wip }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "herrera-io/phar-update": "~2.0",
     "pimple/pimple": "^3.0",
     "symfony/event-dispatcher": "~2.7",
-    "behat/behat": "^3.0"
+    "behat/behat": "^3.0",
+    "symfony/filesystem": "^2.7"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "herzult/php-ssh": "~1.1",
     "herrera-io/phar-update": "~2.0",
     "pimple/pimple": "^3.0",
-    "symfony/event-dispatcher": "~2.7"
+    "symfony/event-dispatcher": "~2.7",
+    "behat/behat": "^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c96960fcbb4fa0db43cf02f72d5caeba",
+    "hash": "59413a913e2d889553124f1e9c2210c5",
     "packages": [
         {
             "name": "behat/behat",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,187 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cd71422363ebc2e19555c8de9490cf49",
+    "hash": "c96960fcbb4fa0db43cf02f72d5caeba",
     "packages": [
+        {
+            "name": "behat/behat",
+            "version": "v3.0.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Behat.git",
+                "reference": "b35ae3d45332d80c532af69cc36f780a9397a996"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Behat/zipball/b35ae3d45332d80c532af69cc36f780a9397a996",
+                "reference": "b35ae3d45332d80c532af69cc36f780a9397a996",
+                "shasum": ""
+            },
+            "require": {
+                "behat/gherkin": "~4.3",
+                "behat/transliterator": "~1.0",
+                "ext-mbstring": "*",
+                "php": ">=5.3.3",
+                "symfony/class-loader": "~2.1",
+                "symfony/config": "~2.3",
+                "symfony/console": "~2.1",
+                "symfony/dependency-injection": "~2.1",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/translation": "~2.3",
+                "symfony/yaml": "~2.1"
+            },
+            "require-dev": {
+                "phpspec/prophecy-phpunit": "~1.0",
+                "phpunit/phpunit": "~4.0",
+                "symfony/process": "~2.1"
+            },
+            "suggest": {
+                "behat/mink-extension": "for integration with Mink testing framework",
+                "behat/symfony2-extension": "for integration with Symfony2 web framework",
+                "behat/yii-extension": "for integration with Yii web framework"
+            },
+            "bin": [
+                "bin/behat"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Behat": "src/",
+                    "Behat\\Testwork": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Scenario-oriented BDD framework for PHP 5.3",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "Agile",
+                "BDD",
+                "ScenarioBDD",
+                "Scrum",
+                "StoryBDD",
+                "User story",
+                "business",
+                "development",
+                "documentation",
+                "examples",
+                "symfony",
+                "testing"
+            ],
+            "time": "2015-02-22 14:10:33"
+        },
+        {
+            "name": "behat/gherkin",
+            "version": "v4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Gherkin.git",
+                "reference": "43777c51058b77bcd84a8775b7a6ad05e986b5db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/43777c51058b77bcd84a8775b7a6ad05e986b5db",
+                "reference": "43777c51058b77bcd84a8775b7a6ad05e986b5db",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "symfony/yaml": "~2.1"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to parse features, represented in YAML files"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Gherkin": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Gherkin DSL parser for PHP 5.3",
+            "homepage": "http://behat.org/",
+            "keywords": [
+                "BDD",
+                "Behat",
+                "Cucumber",
+                "DSL",
+                "gherkin",
+                "parser"
+            ],
+            "time": "2014-06-06 01:24:32"
+        },
+        {
+            "name": "behat/transliterator",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Transliterator.git",
+                "reference": "c93521d3462a554332d1ef5bb0e9b5b8ca4106c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/c93521d3462a554332d1ef5bb0e9b5b8ca4106c4",
+                "reference": "c93521d3462a554332d1ef5bb0e9b5b8ca4106c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\Transliterator": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Artistic-1.0"
+            ],
+            "description": "String transliterator",
+            "keywords": [
+                "i18n",
+                "slug",
+                "transliterator"
+            ],
+            "time": "2014-05-15 22:08:22"
+        },
         {
             "name": "herrera-io/json",
             "version": "1.0.3",
@@ -554,6 +733,106 @@
             "time": "2015-06-25 11:25:37"
         },
         {
+            "name": "symfony/class-loader",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ClassLoader.git",
+                "reference": "84843730de48ca0feba91004a03c7c952f8ea1da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ClassLoader/zipball/84843730de48ca0feba91004a03c7c952f8ea1da",
+                "reference": "84843730de48ca0feba91004a03c7c952f8ea1da",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/finder": "~2.0,>=2.0.5",
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ClassLoader\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ClassLoader Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-08 09:37:21"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Config.git",
+                "reference": "58ded81f1f582a87c528ef3dae9a859f78b5f374"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/58ded81f1f582a87c528ef3dae9a859f78b5f374",
+                "reference": "58ded81f1f582a87c528ef3dae9a859f78b5f374",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/filesystem": "~2.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Config Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-11 14:06:56"
+        },
+        {
             "name": "symfony/console",
             "version": "v2.7.1",
             "source": {
@@ -609,6 +888,66 @@
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
             "time": "2015-06-10 15:30:22"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/DependencyInjection.git",
+                "reference": "1a409e52a38ec891de0a7a61a191d1c62080b69d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/1a409e52a38ec891de0a7a61a191d1c62080b69d",
+                "reference": "1a409e52a38ec891de0a7a61a191d1c62080b69d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "conflict": {
+                "symfony/expression-language": "<2.6"
+            },
+            "require-dev": {
+                "symfony/config": "~2.2",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/yaml": "~2.1"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-11 19:13:11"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -669,6 +1008,55 @@
             "time": "2015-06-08 09:37:21"
         },
         {
+            "name": "symfony/filesystem",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a0d43eb3e17d4f4c6990289805a488a0482a07f3",
+                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-08 09:37:21"
+        },
+        {
             "name": "symfony/process",
             "version": "v2.7.1",
             "source": {
@@ -716,6 +1104,116 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "time": "2015-06-08 09:37:21"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Translation.git",
+                "reference": "8349a2b0d11bd0311df9e8914408080912983a0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/8349a2b0d11bd0311df9e8914408080912983a0b",
+                "reference": "8349a2b0d11bd0311df9e8914408080912983a0b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "conflict": {
+                "symfony/config": "<2.7"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.7",
+                "symfony/intl": "~2.3",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/yaml": "~2.2"
+            },
+            "suggest": {
+                "psr/log": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Translation Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-11 17:26:34"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/9808e75c609a14f6db02f70fccf4ca4aab53c160",
+                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-10 15:30:22"
         }
     ],
     "packages-dev": [
@@ -1385,55 +1883,6 @@
             "time": "2015-02-22 15:13:53"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v2.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a0d43eb3e17d4f4c6990289805a488a0482a07f3",
-                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Filesystem Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
-        },
-        {
             "name": "symfony/finder",
             "version": "v2.7.1",
             "source": {
@@ -1578,19 +2027,11 @@
             "time": "2014-11-11 03:54:14"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [
-
-    ],
-    "platform-dev": [
-
-    ]
+    "platform": [],
+    "platform-dev": []
 }

--- a/features/bootstrap/ApplicationTesterContext.php
+++ b/features/bootstrap/ApplicationTesterContext.php
@@ -1,0 +1,87 @@
+<?php
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Dock\Containers\Container;
+
+class ApplicationTesterContext implements Context, SnippetAcceptingContext
+{
+    private $container;
+
+    const CONTAINER_ID = '12541255';
+    const FAKE_DNS = 'docker.hostname';
+
+    public function __construct()
+    {
+        $this->container = require __DIR__.'/app/container.php';
+    }
+
+    /**
+     * @Given I have a Docker Compose file that contains one container
+     */
+    public function iHaveADockerComposeFileThatContainsOneContainer()
+    {
+        $this->container['containers.configured_container_ids']->setIds([self::CONTAINER_ID]);
+    }
+
+    /**
+     * @Given this container is running
+     */
+    public function thisContainerIsRunning()
+    {
+        $this->container['containers.container_details']->setState(self::CONTAINER_ID, Container::STATE_RUNNING, self::FAKE_DNS);
+    }
+
+    /**
+     * @Given this container ran previously but is not currently running
+     */
+    public function thisContainerIsNotRunning()
+    {
+        $this->container['containers.container_details']->setState(self::CONTAINER_ID, Container::STATE_EXITED, self::FAKE_DNS);
+    }
+
+    /**
+     * @When I run the :command command
+     */
+    public function iRunTheCommand($command)
+    {
+        $this->container['application_tester']->run([$command]);
+    }
+
+    /**
+     * @Then I should see that this container has a status of :status
+     */
+    public function iShouldSeeThatThisContainerHasAStatusOf($status)
+    {
+        $output = $this->getApplicationOutput();
+
+        if (!preg_match('/CONTAINER_' . self::CONTAINER_ID . '.*' . preg_quote($status) . '/', $output)) {
+            throw new \Exception("Container status was not $status");
+        }
+    }
+
+    /**
+     * @Then I should see the DNS resolution of the container
+     */
+    public function iShouldSeeTheDnsResolutionOfTheContainer()
+    {
+        $output = $this->getApplicationOutput();
+
+        if (!preg_match('/CONTAINER_' . self::CONTAINER_ID . '.*' . preg_quote(self::FAKE_DNS) . '/', $output)) {
+            throw new \Exception("Container DNS was not displayed as ". self::FAKE_DNS);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function getApplicationOutput()
+    {
+        $output = $this->container['application_tester']->getDisplay();
+
+        return $output;
+    }
+}

--- a/features/bootstrap/Fake/ConfiguredContainerIds.php
+++ b/features/bootstrap/Fake/ConfiguredContainerIds.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Fake;
+
+class ConfiguredContainerIds implements \Dock\Containers\ConfiguredContainerIds
+{
+    private $ids = [];
+
+    public function setIds(array $ids)
+    {
+        $this->ids = $ids;
+    }
+
+    /**
+     * @return array
+     */
+    public function findAll()
+    {
+        return $this->ids;
+    }
+}

--- a/features/bootstrap/Fake/ContainerDetails.php
+++ b/features/bootstrap/Fake/ContainerDetails.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Fake;
+
+use Dock\Containers\Container;
+
+class ContainerDetails implements \Dock\Containers\ContainerDetails
+{
+    private $states = [];
+
+    public function setState($id, $state, $dns)
+    {
+        $this->states[$id] = ['state'=> $state, 'hosts' => [$dns]];
+    }
+
+    /**
+     * @param string $containerId
+     * @return Container
+     */
+    public function findById($containerId)
+    {
+        if (!array_key_exists($containerId, $this->states)) {
+            throw new \RuntimeException('Asking for undefined state');
+        }
+
+        return new Container(
+            "CONTAINER_$containerId",
+            'IMG',
+            $this->states[$containerId]['state'],
+            $this->states[$containerId]['hosts']
+        );
+    }
+}

--- a/features/bootstrap/SmokeContext.php
+++ b/features/bootstrap/SmokeContext.php
@@ -1,0 +1,92 @@
+<?php
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+
+/**
+ * Defines application features from the specific context.
+ */
+class SmokeContext implements Context, SnippetAcceptingContext
+{
+    private $fs;
+
+    private $lastOutput;
+
+    /**
+     * Initializes context.
+     *
+     * Every scenario gets its own context instance.
+     * You can also pass arbitrary arguments to the
+     * context constructor through behat.yml.
+     */
+    public function __construct()
+    {
+        $this->fs = new \Symfony\Component\Filesystem\Filesystem();
+    }
+
+    /**
+     * @Given I have a Docker Compose file that contains one container
+     */
+    public function iHaveADockerComposeFileThatContainsOneContainer()
+    {
+        $path = __DIR__ . '/../../tmp/';
+        $this->fs->remove($path);
+        $this->fs->mkdir($path);
+        chdir($path);
+
+        $config = <<<EOF
+memcached:
+  image: memcached
+EOF;
+
+        $this->fs->dumpFile('docker-compose.yml', $config);
+    }
+
+    /**
+     * @Given this container is running
+     */
+    public function thisContainerIsRunning()
+    {
+        $this->executeCommand('up');
+    }
+
+    /**
+     * @When I run the :command command
+     */
+    public function iRunTheCommand($command)
+    {
+        $this->lastOutput = $this->executeCommand($command);
+    }
+
+    /**
+     * @Then I should see that this container has a status of :status
+     */
+    public function iShouldSeeThatThisContainerHasAStatusOf($status)
+    {
+        if (!preg_match('/|\s+' . preg_quote($status) . '\s+|$/', $this->lastOutput)) {
+            throw new \Exception("Container status was not $status");
+        }
+    }
+
+    /**
+     * @Then I should see the DNS resolution of the container
+     */
+    public function iShouldSeeTheDnsResolutionOfTheContainer()
+    {
+        if (!preg_match('/|\s+memcached.docker\s+|$/', $this->lastOutput)) {
+            throw new \Exception('Container DNS was not displayed as expected memcached.docker');
+        }
+    }
+
+    /**
+     * @param string $command
+     * @return string
+     */
+    private function executeCommand($command)
+    {
+        return shell_exec(__DIR__ . '/../../bin/dock-cli ' . escapeshellcmd($command));
+    }
+}

--- a/features/bootstrap/app/container.php
+++ b/features/bootstrap/app/container.php
@@ -1,0 +1,24 @@
+<?php
+
+use Fake\ConfiguredContainerIds;
+use Fake\ContainerDetails;
+use Symfony\Component\Console\Tester\ApplicationTester;
+
+$container = require __DIR__.'/../../../app/container.php';
+
+$container['containers.configured_container_ids'] = function ($c) {
+    return new ConfiguredContainerIds();
+};
+
+$container['containers.container_details'] = function ($c) {
+    return new ContainerDetails();
+};
+
+$container['application_tester'] = function($c) {
+    $application = $c['application'];
+    $application->setAutoExit(false);
+
+    return new ApplicationTester($application);
+};
+
+return $container;

--- a/features/inspect-containers.feature
+++ b/features/inspect-containers.feature
@@ -1,0 +1,18 @@
+Feature: Viewing status of containers
+  In order to access my application
+  As a developer
+  I need to see information about my running containers
+
+  Background:
+    Given I have a Docker Compose file that contains one container
+
+  Scenario: Container in config and running
+    Given this container is running
+    When I run the "ps" command
+    Then I should see that this container has a status of "running"
+    And I should see the DNS resolution of the container
+
+  Scenario: Container in config and not running
+    Given this container ran previously but is not currently running
+    When I run the "ps" command
+    Then I should see that this container has a status of "exited"

--- a/features/inspect-containers.feature
+++ b/features/inspect-containers.feature
@@ -6,6 +6,7 @@ Feature: Viewing status of containers
   Background:
     Given I have a Docker Compose file that contains one container
 
+    @smoke
   Scenario: Container in config and running
     Given this container is running
     When I run the "ps" command

--- a/src/Cli/Helper/ContainerList.php
+++ b/src/Cli/Helper/ContainerList.php
@@ -2,7 +2,7 @@
 
 namespace Dock\Cli\Helper;
 
-use Dock\Compose\Container;
+use Dock\Containers\Container;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Cli/PsCommand.php
+++ b/src/Cli/PsCommand.php
@@ -3,7 +3,7 @@
 namespace Dock\Cli;
 
 use Dock\Cli\Helper\ContainerList;
-use Dock\Compose\Inspector;
+use Dock\Containers\ConfiguredContainers;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -11,18 +11,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 class PsCommand extends Command
 {
     /**
-     * @var Inspector
+     * @var ConfiguredContainers
      */
-    private $inspector;
+    private $configuredContainers;
 
     /**
-     * @param Inspector $inspector
+     * @param ConfiguredContainers $configuredContainers
      */
-    public function __construct(Inspector $inspector)
+    public function __construct(ConfiguredContainers $configuredContainers)
     {
         parent::__construct();
 
-        $this->inspector = $inspector;
+        $this->configuredContainers = $configuredContainers;
     }
 
     /**
@@ -41,7 +41,7 @@ class PsCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $containers = $this->inspector->getRunningContainers();
+        $containers = $this->configuredContainers->findAll();
 
         $list = new ContainerList($output);
         $list->render($containers);

--- a/src/Containers/ConfiguredContainerIds.php
+++ b/src/Containers/ConfiguredContainerIds.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Dock\Containers;
+
+interface ConfiguredContainerIds
+{
+    /**
+     * @return array
+     */
+    public function findAll();
+}

--- a/src/Containers/ConfiguredContainers.php
+++ b/src/Containers/ConfiguredContainers.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Dock\Containers;
+
+use Dock\Containers\ContainerDetails;
+use Dock\Containers\ConfiguredContainerIds;
+
+class ConfiguredContainers
+{
+    /**
+     * @var ConfiguredContainerIds
+     */
+    private $configuredContainerIds;
+
+    /**
+     * @var ContainerDetails
+     */
+    private $containerDetails;
+
+    /**
+     * @param ConfiguredContainerIds $configuredContainerIds
+     * @param ContainerDetails $containerDetails
+     */
+    public function __construct(ConfiguredContainerIds $configuredContainerIds, ContainerDetails $containerDetails)
+    {
+        $this->configuredContainerIds = $configuredContainerIds;
+        $this->containerDetails = $containerDetails;
+    }
+
+    /**
+     * @return Container[]
+     */
+    public function findAll()
+    {
+        return array_map([$this, 'findContainerById'], $this->getRunningContainerIds());
+    }
+
+    /**
+     * @return array
+     */
+    private function getRunningContainerIds()
+    {
+        return $this->configuredContainerIds->findAll();
+    }
+
+    /**
+     * @param string $containerId
+     * @return Container
+     */
+    private function findContainerById($containerId)
+    {
+        return $this->containerDetails->findById($containerId);
+    }
+}

--- a/src/Containers/Container.php
+++ b/src/Containers/Container.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dock\Compose;
+namespace Dock\Containers;
 
 class Container
 {

--- a/src/Containers/ContainerDetails.php
+++ b/src/Containers/ContainerDetails.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Dock\Containers;
+
+interface ContainerDetails
+{
+    /**
+     * @param string $containerId
+     * @return Container
+     */
+    public function findById($containerId);
+}

--- a/src/DockerCompose/ConfiguredContainerIds.php
+++ b/src/DockerCompose/ConfiguredContainerIds.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Dock\DockerCompose;
+
+use Dock\IO\ProcessRunner;
+
+class ConfiguredContainerIds implements \Dock\Containers\ConfiguredContainerIds
+{
+    /**
+     * @var ProcessRunner
+     */
+    private $processRunner;
+
+    public function __construct(ProcessRunner $processRunner)
+    {
+        $this->processRunner = $processRunner;
+    }
+
+    /**
+     * @return array
+     */
+    public function findAll()
+    {
+        $rawOutput = $this->processRunner->run('docker-compose ps -q')->getOutput();
+        $lines = explode("\n", $rawOutput);
+        $containerIds = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if (!empty($line)) {
+                $containerIds[] = $line;
+            }
+        }
+
+        return $containerIds;
+    }
+}


### PR DESCRIPTION
Two suites:
- Application - uses Symfony application tester and stubs out the shell commands with fakes
- Smoke - executes CLI command directly and assumes host has lots of stuff already installed

Smoke suite should probably run the `docker:install` command eventually, and needs to do more setup/teardown when further scenarios are added.
