### PR TITLE
Add the `--memory` option to `docker:restart` command

### DIFF
--- a/docs/cmd-docker-restart.md
+++ b/docs/cmd-docker-restart.md
@@ -6,4 +6,9 @@ This command simply restarts the virtual machine running Docker.
 dock-cli docker:restart
 ```
 
+## Available options
+
+- `--memory=X` (or `-m X`) where `X` is the number of MB of memory you want to allocate to the Dinghy VM. This parameter will
+  be persisted across restarts.
+
 Right now, it's just stopping the Dinghy virtual machine and then starting it again with the recommended options.

--- a/src/Cli/RestartCommand.php
+++ b/src/Cli/RestartCommand.php
@@ -5,6 +5,7 @@ namespace Dock\Cli;
 use Dock\Dinghy\DinghyCli;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class RestartCommand extends Command
@@ -32,6 +33,7 @@ class RestartCommand extends Command
         $this
             ->setName('docker:restart')
             ->setDescription('Restart Docker')
+            ->addOption('memory', 'm', InputOption::VALUE_REQUIRED, 'Memory (in MB) allocated to the Dinghy VM')
         ;
     }
 
@@ -44,6 +46,6 @@ class RestartCommand extends Command
             $this->dinghy->stop();
         }
 
-        $this->dinghy->start();
+        $this->dinghy->start($input->getOption('memory'));
     }
 }

--- a/src/Dinghy/DinghyCli.php
+++ b/src/Dinghy/DinghyCli.php
@@ -23,11 +23,18 @@ class DinghyCli
     /**
      * Start dinghy.
      *
+     * @param int $memory The memory, in MB, allocated to the virtual machine
+     *
      * @throws ProcessFailedException
      */
-    public function start()
+    public function start($memory = null)
     {
-        $this->processRunner->run('dinghy up --no-proxy');
+        $arguments = ['--no-proxy'];
+        if (null !== $memory) {
+            $arguments[] = '--memory='.$memory;
+        }
+
+        $this->processRunner->run('dinghy up '.implode(' ', $arguments));
     }
 
     /**


### PR DESCRIPTION
In order to fix #48, this PR adds a `--memory` option to the `docker:restart` command to be able to increase the default memory amount of 2G.
