### PR TITLE
Wait for Dinghy interface to be ready before configuring the route

### DIFF
--- a/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
+++ b/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
@@ -8,7 +8,7 @@
   <array>
     <string>bash</string>
     <string>-c</string>
-    <string>sleep 10; sudo /sbin/route -n add -net 172.17.0.0 -netmask 255.255.0.0 -gateway __DINGHY_IP__</string>
+    <string>/usr/sbin/scutil -w State:/Network/Interface/__DINGHY_INTERFACE__/IPv4 -t 0; sudo /sbin/route -n add -net 172.17.0.0 -netmask 255.255.0.0 -gateway __DINGHY_IP__</string>
   </array>
   <key>KeepAlive</key>
   <false/>


### PR DESCRIPTION
Right now, on OSX we've a problem at reboot: the direct routing is not always configured properly.

This PR fixes the problem by waiting the Dinghy's network interface to be up before adding the route.
