### PR TITLE
Run the doctor command before starting containers

### DIFF
--- a/app/container.php
+++ b/app/container.php
@@ -95,7 +95,7 @@ $container['command.restart'] = function ($c) {
 };
 
 $container['command.start'] = function ($c) {
-    return new StartCommand(new InteractiveProcessBuilder($c['console.user_interaction']), $c['console.user_interaction']);
+    return new StartCommand(new InteractiveProcessBuilder($c['console.user_interaction']), $c['console.user_interaction'], $c['doctor']);
 };
 $container['command.stop'] = function ($c) {
     return new StopCommand($c['compose.executable_finder'], $c['console.user_interaction'], $c['process.silent_runner']);


### PR DESCRIPTION
This command implements what we discussed in #73.

That will basically run the doctor command in dry-run mode and if there's a problem and the user wants, run the according fix.
