### PR TITLE
Upgrade to docker machine (Dinghy 0.4.0)

### DIFF
--- a/UPGRADE-0.4.0.md
+++ b/UPGRADE-0.4.0.md
@@ -1,0 +1,18 @@
+# UPGRADE from 0.3.x to 0.4.x
+
+*Note:* there's nothing new on Linux systems.
+
+The release 0.4.0 of `dock-cli` is embracing the new Dinghy release which is using docker-machine to maintain the
+Virtual Machine running Docker for OSX systems.
+
+Before upgrading, we'll need to run the following commands:
+```
+dinghy halt
+dinghy destroy
+```
+
+Then, run the installer again:
+```
+dock-cli docker:install
+```
+

--- a/app/container.mac.php
+++ b/app/container.mac.php
@@ -19,10 +19,7 @@ $container['system.shell_creator'] = function() {
 };
 
 $container['installer.dns.dnsdock'] = function($c) {
-    return new Dns\Mac\DnsDock(new SshClient(new Session(
-        new Configuration(SshClient::DEFAULT_HOSTNAME),
-        new Password(SshClient::DEFAULT_USERNAME, SshClient::DEFAULT_PASSWORD)
-    )), $c['console.user_interaction'], $c['process.interactive_runner']);
+    return new Dns\Mac\DnsDock(new SshClient($c['cli.dinghy']), $c['console.user_interaction'], $c['process.interactive_runner']);
 };
 $container['installer.dns.docker_routing'] = function($c) {
     return new DNS\Mac\DockerRouting($c['cli.dinghy'], $c['console.user_interaction'], $c['process.interactive_runner'], $c['io.phar_file_extractor']);

--- a/app/container.mac.php
+++ b/app/container.mac.php
@@ -40,7 +40,7 @@ $container['installer.task_provider'] = function ($c) {
         new System\Mac\Vagrant($c['console.user_interaction'], $c['process.interactive_runner']),
         new System\Mac\VirtualBox($c['console.user_interaction'], $c['process.interactive_runner']),
         new System\Mac\DockerCompose($c['console.user_interaction'], $c['process.interactive_runner']),
-        new Docker\EnvironmentVariables(new EnvironManipulatorFactory(), $c['console.user_interaction'], $c['process.interactive_runner']),
+        new Docker\EnvironmentVariables(new EnvironManipulatorFactory(), $c['console.user_interaction'], $c['process.interactive_runner'], $c['cli.dinghy']),
     ]);
 };
 

--- a/src/Dinghy/DinghyCli.php
+++ b/src/Dinghy/DinghyCli.php
@@ -48,13 +48,28 @@ class DinghyCli
     }
 
     /**
+     * Create the Dinghy VM.
+     *
+     * @throws ProcessFailedException
+     */
+    public function create()
+    {
+        $this->processRunner->run('dinghy create --provider virtualbox');
+    }
+
+    /**
      * @return string
      */
     public function getVersion()
     {
         $process = $this->processRunner->run('dinghy version');
+        $output = $process->getOutput();
 
-        return $process->getOutput();
+        if (!preg_match('#([0-9\.]+)#', $output, $matches)) {
+            throw new \RuntimeException('Unable to resolve Dinghy\'s version');
+        }
+
+        return $matches[1];
     }
 
     /**
@@ -66,6 +81,17 @@ class DinghyCli
         $dinghyIp = $process->getOutput();
 
         return trim($dinghyIp);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCreated()
+    {
+        $process = $this->processRunner->run('dinghy status');
+        $output = $process->getOutput();
+
+        return strpos($output, 'VM: not created') === false;
     }
 
     /**

--- a/src/Installer/Docker/EnvironmentVariables.php
+++ b/src/Installer/Docker/EnvironmentVariables.php
@@ -62,7 +62,13 @@ class EnvironmentVariables extends InstallerTask implements DependentChainProces
      */
     private function isEnvironmentConfigured()
     {
-        return getenv('DOCKER_HOST') == 'tcp://127.0.0.1:2376';
+        foreach ($this->getEnvironmentVariables() as $environmentVariable) {
+            if (getenv($environmentVariable->getName()) != $environmentVariable->getValue()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -82,7 +88,7 @@ class EnvironmentVariables extends InstallerTask implements DependentChainProces
     }
 
     /**
-     * @return array
+     * @return EnvironmentVariable[]
      */
     protected function getEnvironmentVariables()
     {

--- a/src/Installer/Docker/EnvironmentVariables.php
+++ b/src/Installer/Docker/EnvironmentVariables.php
@@ -2,6 +2,7 @@
 
 namespace Dock\Installer\Docker;
 
+use Dock\Dinghy\DinghyCli;
 use Dock\Installer\InstallerTask;
 use Dock\IO\ProcessRunner;
 use Dock\IO\UserInteraction;
@@ -15,28 +16,38 @@ class EnvironmentVariables extends InstallerTask implements DependentChainProces
      * @var ProcessRunner
      */
     private $processRunner;
+
     /**
      * @var UserInteraction
      */
     private $userInteraction;
+
     /**
      * @var EnvironManipulatorFactory
      */
     private $environManipulatorFactory;
 
     /**
+     * @var DinghyCli
+     */
+    private $dinghy;
+
+    /**
      * @param EnvironManipulatorFactory $environManipulatorFactory
      * @param UserInteraction $userInteraction
      * @param ProcessRunner $processRunner
+     * @param DinghyCli $dinghy
      */
     public function __construct(
         EnvironManipulatorFactory $environManipulatorFactory,
         UserInteraction $userInteraction,
-        ProcessRunner $processRunner
+        ProcessRunner $processRunner,
+        DinghyCli $dinghy
     ) {
         $this->environManipulatorFactory = $environManipulatorFactory;
         $this->userInteraction = $userInteraction;
         $this->processRunner = $processRunner;
+        $this->dinghy = $dinghy;
     }
 
     /**
@@ -94,9 +105,13 @@ class EnvironmentVariables extends InstallerTask implements DependentChainProces
     {
         $userHome = getenv('HOME');
         $environmentVariables = [
-            new EnvironmentVariable('DOCKER_HOST', 'tcp://127.0.0.1:2376'),
-            new EnvironmentVariable('DOCKER_CERT_PATH', $userHome . '/.dinghy/certs'),
+            new EnvironmentVariable('DOCKER_HOST', sprintf(
+                'tcp://%s:2376',
+                $this->dinghy->getIp()
+            )),
+            new EnvironmentVariable('DOCKER_CERT_PATH', $userHome . '/.docker/machine/machines/dinghy'),
             new EnvironmentVariable('DOCKER_TLS_VERIFY', '1'),
+            new EnvironmentVariable('DOCKER_MACHINE_NAME', 'dinghy'),
         ];
 
         return $environmentVariables;

--- a/src/System/Environ/BashEnvironManipulator.php
+++ b/src/System/Environ/BashEnvironManipulator.php
@@ -46,7 +46,7 @@ class BashEnvironManipulator implements EnvironManipulator
     public function has(EnvironmentVariable $environmentVariable)
     {
         $process = $this->processRunner->run(
-            sprintf('grep %s %s', $environmentVariable->getName(), $this->file),
+            sprintf('grep %s=%s %s', $environmentVariable->getName(), $environmentVariable->getValue(), $this->file),
             false
         );
 


### PR DESCRIPTION
Dinghy 0.4.x branch is released and now use `docker-machine`, which improves stability and will probably solve the file sharing permissions.

This PR upgrades the code to match this new version files.
