### PR TITLE
Uses the `.zshrc` file instead of `.zshenv` with ZSH

### DIFF
--- a/src/System/Environ/EnvironManipulatorFactory.php
+++ b/src/System/Environ/EnvironManipulatorFactory.php
@@ -16,7 +16,7 @@ class EnvironManipulatorFactory
 
         $environFile = $userHome.'/.bash_profile';
         if (strpos($shell, 'zsh') !== false) {
-            $environFile = $userHome.'/.zshenv';
+            $environFile = $userHome.'/.zshrc';
         } elseif (strpos($shell, 'fish') !== false) {
             $environFile = $userHome.'/.config/fish/config.fish';
         }


### PR DESCRIPTION
Dunno why but it looks like the docker-machine eval is not possible anymore in the `.zshenv` file.
