### PR TITLE
[DnsDock] Fix for image name including forward slash

### DIFF
--- a/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
+++ b/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
@@ -30,6 +30,6 @@ class DnsDockResolverSpec extends ObjectBehavior
 
     function it_removes_the_slash_in_image_name()
     {
-        $this->getDnsByContainerNameAndImage('container', 'someone/image:latest')->shouldContain('container.someone_image.docker');
+        $this->getDnsByContainerNameAndImage('container', 'someone/image:latest')->shouldContain('container.image.docker');
     }
 }

--- a/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
+++ b/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
@@ -27,4 +27,9 @@ class DnsDockResolverSpec extends ObjectBehavior
     {
         $this->getDnsByContainerNameAndImage('container', 'image:latest')->shouldContain('container.image.docker');
     }
+
+    function it_removes_the_slash_in_image_name()
+    {
+        $this->getDnsByContainerNameAndImage('container', 'someone/image:latest')->shouldContain('container.someone_image.docker');
+    }
 }

--- a/src/Docker/Dns/DnsDockResolver.php
+++ b/src/Docker/Dns/DnsDockResolver.php
@@ -34,6 +34,10 @@ class DnsDockResolver implements ContainerAddressResolver
     
     private function stripSlashFromImageName($imageName)
     {
-        return str_replace('/', '_', $imageName);
+        if (false !== ($position = strpos($imageName, '/'))) {
+            $imageName = substr($imageName, $position+1 );
+        }
+
+        return $imageName;
     }
 }

--- a/src/Docker/Dns/DnsDockResolver.php
+++ b/src/Docker/Dns/DnsDockResolver.php
@@ -10,6 +10,7 @@ class DnsDockResolver implements ContainerAddressResolver
     public function getDnsByContainerNameAndImage($containerName, $imageName)
     {
         $imageName = $this->stripTagNameFromImageName($imageName);
+        $imageName = $this->stripSlashFromImageName($imageName);
 
         return [
             $imageName.'.docker',
@@ -29,5 +30,10 @@ class DnsDockResolver implements ContainerAddressResolver
         }
 
         return $imageName;
+    }
+    
+    private function stripSlashFromImageName($imageName)
+    {
+        return str_replace('/', '_', $imageName);
     }
 }


### PR DESCRIPTION
If `docker-compose.yml` has an image name that contains forward slash like 

```
web:
    image: someone/image
```

It results in `web.someone/image.docker` DNS address and it does not work 
`/` seems to be an issue here

This PR enables removing everything before slash in container name.
After this change `dock-cli ps` shows `web.image.docker`.
