### PR TITLE
Avoid E_WARNING when the environ file does not exist

### DIFF
--- a/src/Cli/BuildCommand.php
+++ b/src/Cli/BuildCommand.php
@@ -22,7 +22,7 @@ class BuildCommand extends Command
     private $project;
 
     /**
-     * @param ProjectBuildManager $projectManager
+     * @param ProjectBuildManager $projectBuildManager
      * @param Project $project
      */
     public function __construct(ProjectBuildManager $projectBuildManager, Project $project)

--- a/src/System/Environ/FileEnvironManipulator.php
+++ b/src/System/Environ/FileEnvironManipulator.php
@@ -30,8 +30,6 @@ class FileEnvironManipulator implements EnvironManipulator
      */
     public function has($declaration)
     {
-        $contents = file_get_contents($this->file);
-
-        return strpos($contents, $declaration) !== false;
+        return is_file($this->file) && false !== strpos(file_get_contents($this->file), $declaration);
     }
 }


### PR DESCRIPTION
I use bash and I only had a `.profile` file on my machine so an `E_WARNING` error was launched during the `docker:install` command.

This PR avoids the `E_WARNING` error.
