### PR TITLE
Strip multiple slashes from DNS name.

### DIFF
--- a/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
+++ b/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
@@ -28,14 +28,19 @@ class DnsDockResolverSpec extends ObjectBehavior
         $this->getDnsByContainerNameAndImage('container', 'image:latest')->shouldContain('container.image.docker');
     }
 
-    function it_removes_the_slash_in_image_name()
+    function it_uses_the_last_part_of_the_image_name()
     {
         $this->getDnsByContainerNameAndImage('container', 'someone/image:latest')->shouldContain('container.image.docker');
     }
 
-    function it_removes_more_than_one_slash_in_image_name()
+    function it_uses_the_last_part_of_the_image_name_when_multiple_slashes_are_present()
     {
         $this->getDnsByContainerNameAndImage('container', 'someone/folder/image:latest')
-            ->shouldContain('container.folder_image.docker');
+            ->shouldContain('container.image.docker');
+    }
+
+    function it_replaces_dashes_with_underscores_in_image_name()
+    {
+        $this->getDnsByContainerNameAndImage('container', 'someone/image-foo:latest')->shouldContain('container.image_foo.docker');
     }
 }

--- a/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
+++ b/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
@@ -32,4 +32,10 @@ class DnsDockResolverSpec extends ObjectBehavior
     {
         $this->getDnsByContainerNameAndImage('container', 'someone/image:latest')->shouldContain('container.image.docker');
     }
+
+    function it_removes_more_than_one_slash_in_image_name()
+    {
+        $this->getDnsByContainerNameAndImage('container', 'someone/folder/image:latest')
+            ->shouldContain('container.folder_image.docker');
+    }
 }

--- a/src/Docker/Dns/DnsDockResolver.php
+++ b/src/Docker/Dns/DnsDockResolver.php
@@ -35,7 +35,7 @@ class DnsDockResolver implements ContainerAddressResolver
     
     private function stripSlashFromImageName($imageName)
     {
-        if (false !== ($position = strpos($imageName, '/'))) {
+        if (false !== ($position = strrpos($imageName, '/'))) {
             $imageName = substr($imageName, $position+1 );
         }
 
@@ -44,6 +44,6 @@ class DnsDockResolver implements ContainerAddressResolver
 
     private function sanitiseImageName($imageName)
     {
-        return preg_replace('#/#', '_', $imageName);
+        return str_replace(['/', '-'], '_', $imageName);
     }
 }

--- a/src/Docker/Dns/DnsDockResolver.php
+++ b/src/Docker/Dns/DnsDockResolver.php
@@ -11,6 +11,7 @@ class DnsDockResolver implements ContainerAddressResolver
     {
         $imageName = $this->stripTagNameFromImageName($imageName);
         $imageName = $this->stripSlashFromImageName($imageName);
+        $imageName = $this->sanitiseImageName($imageName);
 
         return [
             $imageName.'.docker',
@@ -39,5 +40,10 @@ class DnsDockResolver implements ContainerAddressResolver
         }
 
         return $imageName;
+    }
+
+    private function sanitiseImageName($imageName)
+    {
+        return preg_replace('#/#', '_', $imageName);
     }
 }


### PR DESCRIPTION
Stops `example.com/subfolder/image` becoming `subfolder/image.docker` in the DNS entry.

Instead, it will become `subfolder_image.docker`.