### PR TITLE
Remove sanitisation of the image name for DNS purposes.

### DIFF
--- a/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
+++ b/spec/Dock/Docker/Dns/DnsDockResolverSpec.php
@@ -38,9 +38,4 @@ class DnsDockResolverSpec extends ObjectBehavior
         $this->getDnsByContainerNameAndImage('container', 'someone/folder/image:latest')
             ->shouldContain('container.image.docker');
     }
-
-    function it_replaces_dashes_with_underscores_in_image_name()
-    {
-        $this->getDnsByContainerNameAndImage('container', 'someone/image-foo:latest')->shouldContain('container.image_foo.docker');
-    }
 }

--- a/src/Docker/Dns/DnsDockResolver.php
+++ b/src/Docker/Dns/DnsDockResolver.php
@@ -11,7 +11,6 @@ class DnsDockResolver implements ContainerAddressResolver
     {
         $imageName = $this->stripTagNameFromImageName($imageName);
         $imageName = $this->stripSlashFromImageName($imageName);
-        $imageName = $this->sanitiseImageName($imageName);
 
         return [
             $imageName.'.docker',
@@ -40,10 +39,5 @@ class DnsDockResolver implements ContainerAddressResolver
         }
 
         return $imageName;
-    }
-
-    private function sanitiseImageName($imageName)
-    {
-        return str_replace(['/', '-'], '_', $imageName);
     }
 }


### PR DESCRIPTION
Dock-cli does not currently interact in any way with dnsdock, so custom aliases
are not set, only the default behaviour.