### PR TITLE
Add additional networks for OSX, to support docker-compose v2's networking.

### DIFF
--- a/src/Installer/DNS/Mac/DockerRouting.php
+++ b/src/Installer/DNS/Mac/DockerRouting.php
@@ -79,8 +79,8 @@ class DockerRouting extends InstallerTask implements DependentChainProcessInterf
      */
     private function configureRouting($machineIp)
     {
-        $this->processRunner->run('sudo route -n delete 172.17.0.0/16', false);
-        $this->processRunner->run(sprintf('sudo route -n add 172.17.0.0/16 %s', $machineIp));
+        $this->processRunner->run('sudo route -n delete 172.17.0.0/12', false);
+        $this->processRunner->run(sprintf('sudo route -n add 172.17.0.0/12 %s', $machineIp));
     }
 
     /**

--- a/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
+++ b/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
@@ -8,7 +8,7 @@
   <array>
     <string>bash</string>
     <string>-c</string>
-    <string>/usr/sbin/scutil -w State:/Network/Interface/__MACHINE_INTERFACE__/IPv4 -t 0; for i in $(seq 18 30); do sudo /sbin/route -n add -net "172.$i.0.0" -netmask 255.255.0.0 -gateway __MACHINE_IP__ ; done</string>
+    <string>/usr/sbin/scutil -w State:/Network/Interface/__MACHINE_INTERFACE__/IPv4 -t 0; for i in $(seq 17 30); do sudo /sbin/route -n add -net "172.$i.0.0" -netmask 255.255.0.0 -gateway __MACHINE_IP__ ; done</string>
   </array>
   <key>KeepAlive</key>
   <false/>

--- a/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
+++ b/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
@@ -8,7 +8,7 @@
   <array>
     <string>bash</string>
     <string>-c</string>
-    <string>/usr/sbin/scutil -w State:/Network/Interface/__MACHINE_INTERFACE__/IPv4 -t 0; for i in $(seq 17 30); do sudo /sbin/route -n add -net "172.$i.0.0" -netmask 255.255.0.0 -gateway __MACHINE_IP__ ; done</string>
+    <string>/usr/sbin/scutil -w State:/Network/Interface/__MACHINE_INTERFACE__/IPv4 -t 0; sudo /sbin/route -n add -net "172.17.0.0/12" -gateway __MACHINE_IP__</string>
   </array>
   <key>KeepAlive</key>
   <false/>

--- a/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
+++ b/src/Installer/DNS/Mac/fixtures/com.docker.route.plist
@@ -8,7 +8,7 @@
   <array>
     <string>bash</string>
     <string>-c</string>
-    <string>/usr/sbin/scutil -w State:/Network/Interface/__MACHINE_INTERFACE__/IPv4 -t 0; sudo /sbin/route -n add -net 172.17.0.0 -netmask 255.255.0.0 -gateway __MACHINE_IP__</string>
+    <string>/usr/sbin/scutil -w State:/Network/Interface/__MACHINE_INTERFACE__/IPv4 -t 0; for i in $(seq 18 30); do sudo /sbin/route -n add -net "172.$i.0.0" -netmask 255.255.0.0 -gateway __MACHINE_IP__ ; done</string>
   </array>
   <key>KeepAlive</key>
   <false/>


### PR DESCRIPTION
172.17.0.0 isn't the only network created by docker-compose anymore.