### PR TITLE
Workaround for PHP7 SSH2 segmentation fault - caused by passing empty…

### DIFF
--- a/src/Docker/Machine/SshClient.php
+++ b/src/Docker/Machine/SshClient.php
@@ -46,7 +46,7 @@ class SshClient
             $this->exec = $this->getSession()->getExec();
         }
 
-        return $this->exec->run($command);
+        return $this->exec->run($command, null, null);
     }
 
     /**


### PR DESCRIPTION
… array to ssh2_exec as third param (env)