### PR TITLE
Do not assume one remote configured in the git checkout.

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -15,14 +15,14 @@ TAG=$1
 #
 # Tag & build master branch
 #
-git checkout master
+git checkout origin/master
 git tag ${TAG}
 vendor/kherge/box/bin/box build
 
 #
 # Copy executable file into GH pages
 #
-git checkout gh-pages
+git checkout origin/gh-pages
 
 cp $PHAR_NAME.phar downloads/$PHAR_NAME-${TAG}.phar
 git add downloads/$PHAR_NAME-${TAG}.phar
@@ -51,7 +51,7 @@ git commit -m "Bump version ${TAG}"
 #
 # Go back to master
 #
-git checkout master
+git checkout origin/master
 
 echo "New version created. Now you should run:"
 echo "git push origin gh-pages"


### PR DESCRIPTION
When attempting to release, the script failed as I had my fork configured as a remote as well as origin.