### PR TITLE
Change docker machine name to inviqa-dock-cli.

### DIFF
--- a/src/Docker/Machine/DockerMachineCli.php
+++ b/src/Docker/Machine/DockerMachineCli.php
@@ -7,7 +7,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class DockerMachineCli implements Machine
 {
-    const DEFAULT_MACHINE_NAME = 'dinghy';
+    const DEFAULT_MACHINE_NAME = 'inviqa-dock-cli';
 
     /**
      * @var ProcessRunner


### PR DESCRIPTION
There's no references to Dinghy anywhere else so I assume this was leftover.
I've renamed it so you don't conflict with dinghy installations.